### PR TITLE
fix: 显式导入 TOOL_RUNTIME_SCHEDULER,防止静默解析旧 dsh-tools 副本

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -18,7 +18,7 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { defineTool } from '@deepseek-ai/dsh-tools'
+import { defineTool, TOOL_RUNTIME_SCHEDULER } from '@deepseek-ai/dsh-tools'
 import {
   convertClaudeJsonl, convertCodexJsonl, convertChatgptJson, convertCursorJsonl,
   convertGeminiJson, convertReasonixJsonl, convertPiJsonl, convertOpencodeJson,
@@ -1667,6 +1667,13 @@ async function readBody(req) {
 }
 
 function apply(ctx) {
+  // 声明 TOOL_RUNTIME_SCHEDULER 命名导入：一旦解析到旧副本 dsh-tools@0.0.1-rc.1
+  //（只导出 TOOL_REGISTRY_SCHEDULER），模块加载即失败并大声报错，而不是静默用旧
+  // ABI 注册工具、最终让宿主 agent-loop 在调度时崩溃
+  //（Cannot read properties of undefined (reading 'prepare')）并污染会话历史。
+  if (typeof TOOL_RUNTIME_SCHEDULER !== 'symbol') {
+    throw new Error('dsh-chat-import: resolved @deepseek-ai/dsh-tools lacks TOOL_RUNTIME_SCHEDULER — requires ^0.1.0-rc.6')
+  }
   // REQ-24 imports registry 目录：$DSH_HOME/dsh-chat-import（$DSH_HOME 缺省 ~/.dsh）
   const registryDir = resolveRegistryDir()
   ctx.tools.register(makeImportTool(ctx, {


### PR DESCRIPTION
宿主 DSH 0.1.0-rc.6 的调度器 Symbol 为 TOOL_RUNTIME_SCHEDULER。当 profile 中因其他旧插件 hoist 出 dsh-tools@0.0.1-rc.1 时,本插件的 peer ^0.1.0-rc.6 未被满足,import 仍静默解析到旧副本(只导出 TOOL_REGISTRY_SCHEDULER),宿主 agent-loop 在首个工具调用时崩溃(Cannot read properties of undefined (reading 'prepare'))。本 PR 显式命名导入 TOOL_RUNTIME_SCHEDULER 并在 apply 中做断言:解析到旧副本时模块加载/激活即大声报错,而不是静默使用错误 ABI。测试:342/342 通过。

Fixes #4