### PR TITLE
feat: add DSH session-log source, local JSONL import, and panel upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@
 根目录只放发布到 GitHub / npm 的文件；本地工程文件一律收进 `dev/`（gitignore，永不提交）。
 
 ```
-index.mjs        插件入口（薄组合层，host 面）：只做组装——registerTools（lib/tools.mjs 注册 14 个
-                 导入工具 + scan_discover + export_claude + sync_to_claude + list_imported_sessions +
+index.mjs        插件入口（薄组合层，host 面）：只做组装——registerTools（lib/tools.mjs 注册 15 个
+                 导入工具（14 个来源 + import_local_jsonl） + scan_discover + export_claude + sync_to_claude + list_imported_sessions +
                  retract_import）+ ctx.inject(['webServer']) 延迟挂载面板路由
                  （POST /api-import/sessions 发现、POST /api-import/import 面板导入）
 lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯函数）：imports.mjs（幂等 registry）、
@@ -27,7 +27,7 @@ lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯�
                  memory/CLAUDE.md/skills 桥进 scoped systemPrompt/skills，默认关 env 开关）、opencode.mjs / zcode.mjs / hermes.mjs
                  （SQLite 读取，node:sqlite）、convert/（转换核心按源拆分）、export/（反向序列化按目标
                  格式拆分，当前仅 claude.mjs）
-convert.mjs      转换核心 re-export shim（已按源拆到 lib/convert/{core,claude,codex,chatgpt,cursor,gemini,reasonix,opencode,zcode,grokbuild,openclaw,hermes,pi,kimi}.mjs，纯函数、零 DSH 依赖、可独立单测）
+convert.mjs      转换核心 re-export shim（已按源拆到 lib/convert/{core,claude,codex,chatgpt,cursor,gemini,reasonix,opencode,zcode,grokbuild,openclaw,hermes,pi,kimi,dsh,local-jsonl}.mjs，纯函数、零 DSH 依赖、可独立单测）
 export.mjs       反向导出序列化器 re-export shim（实体在 lib/export/claude.mjs——DSH 会话日志 → Claude
                  Code JSONL，纯函数、零 DSH 依赖；`exports["./export.mjs"]` 子路径契约保持不变）
 cordis.patch.yml bundle 声明（insert import-claude）
@@ -51,7 +51,7 @@ npm test        # node --test 跑 test/*.test.mjs（convert 单测 + export 单�
 npm run check:linux   # 跨平台路径纪律静态检查（.github/scripts/check-linux-compat.mjs，CI 同款护栏）
 ```
 
-无构建步骤：纯 ESM，`index.mjs` / `convert.mjs` / `export.mjs` / `lib/` 即发布产物（`lib/client.js` 是手写 CJS bundle，亦无构建）。DSH 手工验证：`dsh plugin --profile web add -w link:<本仓库路径>` 后重启 dsh，在会话里调任一 `import_*`（14 个）/ `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import`；Browser 侧验证：dsh web 侧边栏底部「导入会话」按钮 → 面板按工作区分组浏览 + 单选/多选导入。
+无构建步骤：纯 ESM，`index.mjs` / `convert.mjs` / `export.mjs` / `lib/` 即发布产物（`lib/client.js` 是手写 CJS bundle，亦无构建）。DSH 手工验证：`dsh plugin --profile web add -w link:<本仓库路径>` 后重启 dsh，在会话里调任一 `import_*`（15 个）/ `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import`；Browser 侧验证：dsh web 侧边栏底部「导入会话」按钮 → 面板按工作区分组浏览 + 单选/多选导入。
 
 ## 提交纪律（保持仓库干净）
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@
 根目录只放发布到 GitHub / npm 的文件；本地工程文件一律收进 `dev/`（gitignore，永不提交）。
 
 ```
-index.mjs        插件入口（薄组合层，host 面）：只做组装——registerTools（lib/tools.mjs 注册 13 个
+index.mjs        插件入口（薄组合层，host 面）：只做组装——registerTools（lib/tools.mjs 注册 14 个
                  导入工具 + scan_discover + export_claude + sync_to_claude + list_imported_sessions +
                  retract_import）+ ctx.inject(['webServer']) 延迟挂载面板路由
                  （POST /api-import/sessions 发现、POST /api-import/import 面板导入）
 lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯函数）：imports.mjs（幂等 registry）、
-                 backfill.mjs（sync_to_claude 写回）、discovery.mjs（13 格式统一发现 + 30s TTL / 持久化
+                 backfill.mjs（sync_to_claude 写回）、discovery.mjs（14 格式统一发现 + 30s TTL / 持久化
                  书签）、budget.mjs（REQ-37 预算解析链）、import-core.mjs（共享导入编排：importTranscript
                  状态机 / importDirectory / runDecision 落盘 / 归组 / 标准预览）、import-variants.mjs
                  （chatgpt / grokbuild / hermes / kimi 编排 + opencode / zcode 等 dry-run 预览）、toolkit.mjs
@@ -41,7 +41,7 @@ test/            convert 单测 + export 单测 + index mock 集成 + zcode 自�
 dev/             ❌ 本地工程面（gitignore，永不提交）：bin/（脚本：session.mjs 多会话认领 CLI、verify-*、totp）、hooks/（pre-push）、research/（竞品/方向调研）、HANDOFF.md、REQUIREMENTS.md、GROWTH.md、RELEASING.md、ORCHESTRATOR-PROMPT.md、TESTER-PROMPT.md、gh-pat.txt（凭据勿提交）；多会话协调靠 dsh-file-claim 插件
 ```
 
-- `package.json` 的 `files` 白名单就是 npm 发布面：`index.mjs`、`convert.mjs`、`export.mjs`、`lib/imports.mjs`、`lib/backfill.mjs`、`lib/client.js`、`lib/command.mjs`、`lib/context-bridge.mjs`、`lib/discovery.mjs`、`lib/budget.mjs`、`lib/import-core.mjs`、`lib/import-variants.mjs`、`lib/toolkit.mjs`、`lib/export-tool.mjs`、`lib/prompt-hint.mjs`、`lib/retract.mjs`、`lib/discovery-host.mjs`、`lib/panel.mjs`、`lib/tools.mjs`、`lib/convert`、`lib/export`、`lib/hermes.mjs`、`lib/opencode.mjs`、`lib/zcode.mjs`、`cordis.patch.yml`、`README.md`、`README.zh-CN.md`、`CHANGELOG.md`、`assets/import.svg`、`LICENSE`。新增被 `index.mjs` import 或 README 引用的文件必须同步加进 `files`。
+- `package.json` 的 `files` 白名单就是 npm 发布面：`index.mjs`、`convert.mjs`、`export.mjs`、`lib/imports.mjs`、`lib/backfill.mjs`、`lib/client.js`、`lib/command.mjs`、`lib/context-bridge.mjs`、`lib/discovery.mjs`、`lib/budget.mjs`、`lib/import-core.mjs`、`lib/import-variants.mjs`、`lib/toolkit.mjs`、`lib/export-tool.mjs`、`lib/prompt-hint.mjs`、`lib/retract.mjs`、`lib/discovery-host.mjs`、`lib/panel.mjs`、`lib/tools.mjs`、`lib/dsh.mjs`、`lib/convert`、`lib/export`、`lib/hermes.mjs`、`lib/opencode.mjs`、`lib/zcode.mjs`、`cordis.patch.yml`、`README.md`、`README.zh-CN.md`、`CHANGELOG.md`、`assets/import.svg`、`LICENSE`。新增被 `index.mjs` import 或 README 引用的文件必须同步加进 `files`。
 - **永不提交**：`dev/`、`node_modules/`、`.prev-session*.jsonl`、`.dsh-file-claim/`（插件运行时目录）、真实用户 transcript（含敏感内容）、任何凭据/密钥。
 
 ## 命令
@@ -51,7 +51,7 @@ npm test        # node --test 跑 test/*.test.mjs（convert 单测 + export 单�
 npm run check:linux   # 跨平台路径纪律静态检查（.github/scripts/check-linux-compat.mjs，CI 同款护栏）
 ```
 
-无构建步骤：纯 ESM，`index.mjs` / `convert.mjs` / `export.mjs` / `lib/` 即发布产物（`lib/client.js` 是手写 CJS bundle，亦无构建）。DSH 手工验证：`dsh plugin --profile web add -w link:<本仓库路径>` 后重启 dsh，在会话里调任一 `import_*`（13 个）/ `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import`；Browser 侧验证：dsh web 侧边栏底部「导入会话」按钮 → 面板按工作区分组浏览 + 单选/多选导入。
+无构建步骤：纯 ESM，`index.mjs` / `convert.mjs` / `export.mjs` / `lib/` 即发布产物（`lib/client.js` 是手写 CJS bundle，亦无构建）。DSH 手工验证：`dsh plugin --profile web add -w link:<本仓库路径>` 后重启 dsh，在会话里调任一 `import_*`（14 个）/ `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import`；Browser 侧验证：dsh web 侧边栏底部「导入会话」按钮 → 面板按工作区分组浏览 + 单选/多选导入。
 
 ## 提交纪律（保持仓库干净）
 
@@ -102,7 +102,7 @@ npm run check:linux   # 跨平台路径纪律静态检查（.github/scripts/chec
 ## 质量约定
 
 - 文件以**恰好一个**换行结尾；空 `catch` 必须说明吞掉什么且 `try` 只包一条语句；不注释代码里显而易见的事实。
-- 保持 `lib/convert/*` 与 `lib/export/*`（含根 shim `convert.mjs` / `export.mjs`）零依赖纯函数：任何 DSH 依赖只允许出现在 `index.mjs` 与 `lib/{imports,backfill,opencode,zcode,hermes,discovery,budget,import-core,import-variants,toolkit,export-tool,retract,discovery-host,panel,tools}.mjs`（即所有消费 ctx 的 host 面模块）。
+- 保持 `lib/convert/*` 与 `lib/export/*`（含根 shim `convert.mjs` / `export.mjs`）零依赖纯函数：任何 DSH 依赖只允许出现在 `index.mjs` 与 `lib/{imports,backfill,opencode,zcode,hermes,dsh,discovery,budget,import-core,import-variants,toolkit,export-tool,retract,discovery-host,panel,tools}.mjs`（即所有消费 ctx 的 host 面模块）。
 - 测试描述行为而非背书正确性；fixtures 用合成数据，永不掺真实 transcript。
 - **跨平台路径纪律（防 CI 红，`npm run check:linux` 护栏）**：CI 在 Linux 跑 `npm test`，测试里的反斜杠合成路径经代码 `node:path` 运算在 posix 下行为不同（`join()` 产混合分隔符、`dirname('D:\…')` 返 `'.'`）。规则：mock 树查找（`stat`/`readText`/`listDir` 读树）必须做分隔符归一（复用 `index.test.mjs` makeCtx 的 `norm` + `lookup` 三态命中）；断言若比较 `node:path` 运算结果，期望值用同口径函数计算，绝不写死 `'X:\…'` 字面量；新增导入测试优先用真实临时目录（`mkdtemp`）。
 - 不写行内文档废话：注释写契约与上下文，不叙述控制流。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Release dates are the npm publish timestamps in Asia/Shanghai (UTC+8).
 
 ### Added
 
+- **Local JSONL session-file import (auto-detect)** — new
+  `import_local_jsonl` tool accepts any local `.jsonl` file or directory and
+  auto-detects the transcript structure across `dsh` / `claude` / `codex` /
+  `cursor` / `reasonix` / `pi` / `openclaw` / `hermes` (path hints order the
+  candidates; the first converter that yields a session wins), with an
+  optional `format` parameter to force one parser. Directory mode imports
+  every `.jsonl` as its own session through the same idempotent/incremental
+  state machine. `npm test` — 391 cases.
+
 - **DSH session-log source (14th import source)** — new `import_dsh` tool
   imports DeepSeek Harness' own session logs (`session.jsonl` and
   `session.jsonl.zstd`, default root `~/.dsh/sessions`), decompressing zstd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Release dates are the npm publish timestamps in Asia/Shanghai (UTC+8).
 
 ### Added
 
+- **DSH session-log source (14th import source)** — new `import_dsh` tool
+  imports DeepSeek Harness' own session logs (`session.jsonl` and
+  `session.jsonl.zstd`, default root `~/.dsh/sessions`), decompressing zstd
+  logs with the system `zstd` binary and keeping the durable
+  turn/step/user/assistant/tool events while streaming chunks and runtime
+  state events are dropped. `scan_discover`, the sidebar panel source filter
+  (`dsh`), `/import dsh <path>` and `format: 'dsh'` cover the new source too.
+  The tool-count expectation and README counts move to 14 sources / 19 tools;
+  `npm test` — 387 cases.
+
 - **Kimi CLI source (REQ-14, 13th import source)** — new `import_kimi` tool
   imports Moonshot AI's open-source terminal agent sessions from
   `~/.kimi/sessions/<workdir-md5>/<sessionId>/wire.jsonl` (single session

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 📥 DSH Chat Import
 
-**Import 13 external agent conversation histories into DeepSeek Harness as full-fidelity, resumable sessions — and export / sync back to Claude Code.**
+**Import 14 external agent conversation histories into DeepSeek Harness as full-fidelity, resumable sessions — and export / sync back to Claude Code.**
 
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](#)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](README.zh-CN.md)
@@ -21,7 +21,7 @@
 
 </div>
 
-> **13 agent sources, one plugin** — full-fidelity import into DeepSeek Harness, seamless resume, and export / sync back to Claude Code.
+> **14 agent sources, one plugin** — full-fidelity import into DeepSeek Harness, seamless resume, and export / sync back to Claude Code.
 
 <div align="center">
 
@@ -35,7 +35,7 @@
 
 ## 💡 Concept
 
-`dsh-chat-import` imports conversation histories from **Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, opencode, ZCode, Grok Build, OpenClaw, Pi Coding Agent, Hermes and Kimi CLI** — tool calls, reasoning and all — as **full-fidelity, resumable DeepSeek Harness sessions**. Source files are read **read-only** (never rewritten), the DSH engine is never touched, and every import becomes a fresh session grouped into the workspace of its source `cwd`.
+`dsh-chat-import` imports conversation histories from **Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, opencode, ZCode, Grok Build, OpenClaw, Pi Coding Agent, Hermes, Kimi CLI and DSH session logs** — tool calls, reasoning and all — as **full-fidelity, resumable DeepSeek Harness sessions**. Source files are read **read-only** (never rewritten), the DSH engine is never touched, and every import becomes a fresh session grouped into the workspace of its source `cwd`.
 
 The reverse direction is covered too: `export_claude` serializes a DSH session back into a Claude Code JSONL transcript that Claude Code can load with `--resume` (read-only — your DSH log is never modified), and `sync_to_claude` incrementally appends a session's new turns back to a Claude Code file — guarded, never silently overwriting.
 
@@ -45,7 +45,7 @@ The reverse direction is covered too: `export_claude` serializes a DSH session b
 
 | Category | Feature | Description |
 | --- | --- | --- |
-| Import | **13 sources, one plugin** | One tool per source — from Claude Code JSONL and Codex rollouts to SQLite databases and session directories. |
+| Import | **14 sources, one plugin** | One tool per source — from Claude Code JSONL and Codex rollouts to SQLite databases and session directories. |
 | Import | **Full fidelity** | Tool calls & results, thinking blocks, titles, models and timestamps carry over wherever the source records them. |
 | Import | **Batch import** | Point at a directory (or a whole database) and every file / conversation becomes its own session, with a per-file summary. |
 | Resume | **Seamlessly resumable** | Open an imported session and keep chatting exactly where the source left off. |
@@ -74,6 +74,7 @@ The reverse direction is covered too: `export_claude` serializes a DSH session b
 | **Pi Coding Agent** | `~/.pi/agent/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl` | `import_pi` |
 | **Hermes** | `~/.hermes/` (Windows `%LOCALAPPDATA%\hermes`) | `import_hermes` |
 | **Kimi CLI** | `~/.kimi/sessions/<workdir-md5>/<sessionId>/wire.jsonl` | `import_kimi` |
+| **DSH session logs** | `~/.dsh/sessions/<encoded-workspace>/<sessionId>/session.jsonl(.zstd)` | `import_dsh` |
 
 Each import preserves what the source actually records — session id, `cwd`, title, model, timestamps, tool calls & results, reasoning. Sources that record less import what exists; anything a format cannot preserve is explicitly flagged in the import report (e.g. Kimi sub-agent conversations mirrored into the parent wire as `SubagentEvent` are skipped — the parent's `Agent` tool call & result are kept, and a sub-agent's own `subagents/<agentId>/wire.jsonl` can be imported directly).
 
@@ -88,7 +89,7 @@ dsh plugin --profile web add dsh-chat-import                    # npm package
 dsh plugin --profile web add -w link:/path/to/dsh-chat-import   # local checkout (symlink)
 ```
 
-**2. Import** — in any DSH session, import a single file or a whole directory (the same call shape works for all 13 import tools — see the table above):
+**2. Import** — in any DSH session, import a single file or a whole directory (the same call shape works for all 14 import tools — see the table above):
 
 ```
 import_claude({ path: "~/.claude/projects" })
@@ -140,7 +141,7 @@ Every import result reports its `status` and any anomalies — malformed lines, 
 
 ### scan_discover — read-only session discovery
 
-`scan_discover` scans the known data roots of all 13 formats and returns a structured session index (title, project, path, import status) so you can preview before a batch import. Zero side effects:
+`scan_discover` scans the known data roots of all 14 formats and returns a structured session index (title, project, path, import status) so you can preview before a batch import. Zero side effects:
 
 ```
 scan_discover()
@@ -233,13 +234,13 @@ lib/
 
 ## ⚙️ Compatibility
 
-Targets the `dsh 0.1.x` line (`dsh-tools ^0.1.0-rc.6`, tested on `dsh 0.1.0-rc.6`) and requires **Node.js >= 22.13** (the first release where `node:sqlite` is available without a flag). `npm test` — 385 cases.
+Targets the `dsh 0.1.x` line (`dsh-tools ^0.1.0-rc.6`, tested on `dsh 0.1.0-rc.6`) and requires **Node.js >= 22.13** (the first release where `node:sqlite` is available without a flag). `npm test` — 387 cases.
 
 ---
 
 ## 🗺️ Roadmap
 
-- [x] 13 import sources + reverse export / sync back to Claude Code
+- [x] 14 import sources + reverse export / sync back to Claude Code
 - [x] Browser import panel + `/import` slash command + session-start migration hint & context bridge
 - [ ] Interchange IR v1 + portable backup bundle (REQ-18 / REQ-56)
 - [ ] `/import-all` batch command · Codex App Server API source (REQ-52)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ import_claude({ path: "C:\Users\<you>\.claude\projects\<slug>\<sessionId>.jsonl"
 import_codex({ path: "C:\Users\<you>\.codex\sessions\2026\05\18\rollout-2026-05-18T21-14-16-xxxx.jsonl" })
 import_chatgpt({ path: "C:\Users\<you>\Downloads\chatgpt-export\conversations.json" })
 import_opencode({ path: "C:\Users\<you>\.local\share\opencode\opencode.db" })
+import_local_jsonl({ path: "D:\downloads\session.jsonl" })
+```
+
+`import_local_jsonl({ path })` accepts any local `.jsonl` session file (or directory): it auto-detects `dsh` / `claude` / `codex` / `cursor` / `reasonix` / `pi` / `openclaw` / `hermes`, and the `format` parameter forces one parser when detection is wrong:
+
+```
+import_local_jsonl({ path: "D:\downloads\session.jsonl" })
+import_local_jsonl({ path: "D:\downloads\unknown.jsonl", format: "claude" })
 ```
 
 `import_chatgpt` / `import_opencode` / `import_zcode` / `import_hermes` always return a batch result — one file / database holds all conversations, so each conversation becomes its own session in a single call.
@@ -234,7 +242,7 @@ lib/
 
 ## ⚙️ Compatibility
 
-Targets the `dsh 0.1.x` line (`dsh-tools ^0.1.0-rc.6`, tested on `dsh 0.1.0-rc.6`) and requires **Node.js >= 22.13** (the first release where `node:sqlite` is available without a flag). `npm test` — 387 cases.
+Targets the `dsh 0.1.x` line (`dsh-tools ^0.1.0-rc.6`, tested on `dsh 0.1.0-rc.6`) and requires **Node.js >= 22.13** (the first release where `node:sqlite` is available without a flag). `npm test` — 391 cases.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 # 📥 DSH Chat Import
 
-**把 13 种外部 Agent 聊天历史全保真导入 DeepSeek Harness 为可继续（resume）会话——并可导出 / 同步回 Claude Code。**
+**把 14 种外部 Agent 聊天历史全保真导入 DeepSeek Harness 为可继续（resume）会话——并可导出 / 同步回 Claude Code。**
 
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](README.md)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](#)
@@ -21,7 +21,7 @@
 
 </div>
 
-> **一个插件，13 种来源** —— 全保真导入 DeepSeek Harness，无缝续聊，并可导出 / 同步回 Claude Code。
+> **一个插件，14 种来源** —— 全保真导入 DeepSeek Harness，无缝续聊，并可导出 / 同步回 Claude Code。
 
 <div align="center">
 
@@ -35,7 +35,7 @@
 
 ## 💡 概念
 
-`dsh-chat-import` 从 **Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、opencode、ZCode、Grok Build、OpenClaw、Pi Coding Agent、Hermes 与 Kimi CLI** 导入聊天历史——工具调用、思考过程一应俱全——成为**全保真、可继续（resume）的 DeepSeek Harness 会话**。源文件**只读**读取（绝不改写），不碰 DSH 引擎；每次导入都成为一条全新会话，并按源 `cwd` 归入对应工作区。
+`dsh-chat-import` 从 **Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、opencode、ZCode、Grok Build、OpenClaw、Pi Coding Agent、Hermes、Kimi CLI 与 DSH 会话日志** 导入聊天历史——工具调用、思考过程一应俱全——成为**全保真、可继续（resume）的 DeepSeek Harness 会话**。源文件**只读**读取（绝不改写），不碰 DSH 引擎；每次导入都成为一条全新会话，并按源 `cwd` 归入对应工作区。
 
 反向方向同样覆盖：`export_claude` 把 DSH 会话序列化回 Claude Code JSONL（只读——绝不修改你的 DSH 日志），Claude Code 可用 `--resume` 加载续聊；`sync_to_claude` 再把会话新增轮次增量写回 Claude Code 文件——带守卫、绝不静默覆盖。
 
@@ -45,7 +45,7 @@
 
 | 分类 | 特性 | 说明 |
 | --- | --- | --- |
-| 导入 | **13 种来源，一个插件** | 每种来源一条命令——从 Claude Code JSONL、Codex rollout 到 SQLite 数据库与会话目录。 |
+| 导入 | **14 种来源，一个插件** | 每种来源一条命令——从 Claude Code JSONL、Codex rollout 到 SQLite 数据库与会话目录。 |
 | 导入 | **全保真** | 工具调用与结果、思考块、标题、模型与时间戳，源有记录就原样保留。 |
 | 导入 | **批量导入** | 指向一个目录（或整个数据库），每个文件 / 每段对话都成为独立会话，并返回逐文件汇总。 |
 | 续聊 | **可无缝续聊** | 打开导入的会话，从源记录停下的地方继续对话。 |
@@ -74,6 +74,7 @@
 | **Pi Coding Agent** | `~/.pi/agent/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl` | `import_pi` |
 | **Hermes** | `~/.hermes/`（Windows `%LOCALAPPDATA%\hermes`） | `import_hermes` |
 | **Kimi CLI** | `~/.kimi/sessions/<workdir-md5>/<sessionId>/wire.jsonl` | `import_kimi` |
+| **DSH 会话日志** | `~/.dsh/sessions/<encoded-workspace>/<sessionId>/session.jsonl(.zstd)` | `import_dsh` |
 
 每次导入都会保留源实际记录的内容——sessionId、`cwd`、标题、模型、时间戳、工具调用与结果、思考过程。数据较少的源导入其已有的内容；源格式无法保留的部分，会在导入报告里显式标注（如 Kimi 镜像进父 wire 的 `SubagentEvent` 子代理对话会跳过——父 `Agent` 工具调用与结果保留，子代理自己的 `subagents/<agentId>/wire.jsonl` 可直接导入）。
 
@@ -88,7 +89,7 @@ dsh plugin --profile web add dsh-chat-import                    # npm 包
 dsh plugin --profile web add -w link:/path/to/dsh-chat-import   # 本地源码（符号链接）
 ```
 
-**2. 导入** — 在任意 DSH 会话里导入单个文件或整个目录（13 个导入工具调用方式一致——见上方来源表）：
+**2. 导入** — 在任意 DSH 会话里导入单个文件或整个目录（14 个导入工具调用方式一致——见上方来源表）：
 
 ```
 import_claude({ path: "~/.claude/projects" })
@@ -140,7 +141,7 @@ import_claude({ path: "C:\Users\<you>\.claude\projects\<slug>\<sessionId>.jsonl"
 
 ### scan_discover — 只读会话发现
 
-`scan_discover` 扫描全部 13 种格式的已知数据根，返回结构化会话索引（标题、项目、路径、导入状态），供批导入前预览。零副作用：
+`scan_discover` 扫描全部 14 种格式的已知数据根，返回结构化会话索引（标题、项目、路径、导入状态），供批导入前预览。零副作用：
 
 ```
 scan_discover()
@@ -233,13 +234,13 @@ lib/
 
 ## ⚙️ 兼容性
 
-面向 `dsh 0.1.x` 线（`dsh-tools ^0.1.0-rc.6`，实测 `dsh 0.1.0-rc.6`），需要 **Node.js >= 22.13**（`node:sqlite` 免 flag 的首个版本）。`npm test` — 385 个用例。
+面向 `dsh 0.1.x` 线（`dsh-tools ^0.1.0-rc.6`，实测 `dsh 0.1.0-rc.6`），需要 **Node.js >= 22.13**（`node:sqlite` 免 flag 的首个版本）。`npm test` — 387 个用例。
 
 ---
 
 ## 🗺️ 路线图
 
-- [x] 13 种来源导入 + 反向导出 / 同步回 Claude Code
+- [x] 14 种来源导入 + 反向导出 / 同步回 Claude Code
 - [x] 浏览器导入面板 + `/import` 斜杠命令 + 会话启动迁移提示与上下文桥接
 - [ ] Interchange IR v1 + 便携备份 bundle（REQ-18 / REQ-56）
 - [ ] `/import-all` 批量命令 · Codex 官方 App Server API 源（REQ-52）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,14 @@ import_claude({ path: "C:\Users\<you>\.claude\projects\<slug>\<sessionId>.jsonl"
 import_codex({ path: "C:\Users\<you>\.codex\sessions\2026\05\18\rollout-2026-05-18T21-14-16-xxxx.jsonl" })
 import_chatgpt({ path: "C:\Users\<you>\Downloads\chatgpt-export\conversations.json" })
 import_opencode({ path: "C:\Users\<you>\.local\share\opencode\opencode.db" })
+import_local_jsonl({ path: "D:\downloads\session.jsonl" })
+```
+
+`import_local_jsonl({ path })` 接受任意本地 `.jsonl` 会话文件（或目录）：自动识别 `dsh` / `claude` / `codex` / `cursor` / `reasonix` / `pi` / `openclaw` / `hermes`，识别不准时可用 `format` 参数强制指定：
+
+```
+import_local_jsonl({ path: "D:\downloads\session.jsonl" })
+import_local_jsonl({ path: "D:\downloads\unknown.jsonl", format: "claude" })
 ```
 
 `import_chatgpt` / `import_opencode` / `import_zcode` / `import_hermes` 恒返回批量结果——一个文件 / 数据库包含全部会话，一次调用即可让每段对话成为独立会话。
@@ -234,7 +242,7 @@ lib/
 
 ## ⚙️ 兼容性
 
-面向 `dsh 0.1.x` 线（`dsh-tools ^0.1.0-rc.6`，实测 `dsh 0.1.0-rc.6`），需要 **Node.js >= 22.13**（`node:sqlite` 免 flag 的首个版本）。`npm test` — 387 个用例。
+面向 `dsh 0.1.x` 线（`dsh-tools ^0.1.0-rc.6`，实测 `dsh 0.1.0-rc.6`），需要 **Node.js >= 22.13**（`node:sqlite` 免 flag 的首个版本）。`npm test` — 391 个用例。
 
 ---
 

--- a/convert.mjs
+++ b/convert.mjs
@@ -80,3 +80,8 @@ export {
 export {
   convertDshJsonl,
 } from './lib/convert/dsh.mjs'
+
+export {
+  convertLocalJsonl,
+  LOCAL_JSONL_FORMATS,
+} from './lib/convert/local-jsonl.mjs'

--- a/convert.mjs
+++ b/convert.mjs
@@ -76,3 +76,7 @@ export {
 export {
   convertKimiWire,
 } from './lib/convert/kimi.mjs'
+
+export {
+  convertDshJsonl,
+} from './lib/convert/dsh.mjs'

--- a/index.mjs
+++ b/index.mjs
@@ -12,17 +12,17 @@
 //                           runDecision（落盘）/ 归组 / 投影预热 / 标准 dry-run 预览
 //   lib/import-variants.mjs 特殊形态来源编排：chatgpt / grokbuild / hermes + opencode /
 //                           zcode / hermes / grokbuild / chatgpt 的 dry-run 预览
-//   lib/toolkit.mjs         makeImportTool 工厂（14 个导入工具共享 schema/render/execute
+//   lib/toolkit.mjs         makeImportTool 工厂（15 个导入工具共享 schema/render/execute
 //                           骨架）+ IMPORT_SPECS（REQ-41 面板导入复用同一编排）
 //   lib/export-tool.mjs     export_claude（REQ-16）执行体
 //   lib/retract.mjs         REQ-33 导入识别 / 撤回（list_imported_sessions / retract_import）
 //   lib/discovery-host.mjs  REQ-25/40 scan_discover 的 host 适配（fs + SQLite 摘要）
 //   lib/panel.mjs           REQ-41 面板路由（POST /api-import/sessions + /api-import/import）
-//   lib/tools.mjs           19 个工具的注册（14 导入 + export + sync + 识别/撤回 + 发现）
+//   lib/tools.mjs           20 个工具的注册（15 导入 + export + sync + 识别/撤回 + 发现）
 //
 // 本文件只做组装：registerTools 注册工具；webServer 是可选且晚挂载的 host 服务，
 // 面板路由经 ctx.inject(['webServer']) 延迟注册（headless / 无 Web 的 profile 不挂载
-// 路由但照常 apply，14 个导入工具与 CLI 会话不受影响）。
+// 路由但照常 apply，15 个导入工具与 CLI 会话不受影响）。
 
 import { resolveRegistryDir } from './lib/imports.mjs'
 import { registerTools } from './lib/tools.mjs'

--- a/index.mjs
+++ b/index.mjs
@@ -12,17 +12,17 @@
 //                           runDecision（落盘）/ 归组 / 投影预热 / 标准 dry-run 预览
 //   lib/import-variants.mjs 特殊形态来源编排：chatgpt / grokbuild / hermes + opencode /
 //                           zcode / hermes / grokbuild / chatgpt 的 dry-run 预览
-//   lib/toolkit.mjs         makeImportTool 工厂（13 个导入工具共享 schema/render/execute
+//   lib/toolkit.mjs         makeImportTool 工厂（14 个导入工具共享 schema/render/execute
 //                           骨架）+ IMPORT_SPECS（REQ-41 面板导入复用同一编排）
 //   lib/export-tool.mjs     export_claude（REQ-16）执行体
 //   lib/retract.mjs         REQ-33 导入识别 / 撤回（list_imported_sessions / retract_import）
 //   lib/discovery-host.mjs  REQ-25/40 scan_discover 的 host 适配（fs + SQLite 摘要）
 //   lib/panel.mjs           REQ-41 面板路由（POST /api-import/sessions + /api-import/import）
-//   lib/tools.mjs           18 个工具的注册（13 导入 + export + sync + 识别/撤回 + 发现）
+//   lib/tools.mjs           19 个工具的注册（14 导入 + export + sync + 识别/撤回 + 发现）
 //
 // 本文件只做组装：registerTools 注册工具；webServer 是可选且晚挂载的 host 服务，
 // 面板路由经 ctx.inject(['webServer']) 延迟注册（headless / 无 Web 的 profile 不挂载
-// 路由但照常 apply，13 个导入工具与 CLI 会话不受影响）。
+// 路由但照常 apply，14 个导入工具与 CLI 会话不受影响）。
 
 import { resolveRegistryDir } from './lib/imports.mjs'
 import { registerTools } from './lib/tools.mjs'

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,14 +146,14 @@ window.__ModuleLoader__.load({
     // claude）。chatgpt 无默认数据根，仅显式 path 可发现。
     const SOURCES = [
       "", "claude-code", "codex", "chatgpt", "cursor", "gemini", "reasonix",
-      "opencode", "zcode", "grokbuild", "openclaw", "pi", "hermes", "kimi",
+      "opencode", "zcode", "grokbuild", "openclaw", "pi", "hermes", "kimi", "dsh",
     ];
     // discovery format 短名 → 客户端来源 id（构建 /api-import/import 的 items）。
     const FORMAT_SOURCE = {
       claude: "claude-code", codex: "codex", chatgpt: "chatgpt", cursor: "cursor",
       gemini: "gemini", reasonix: "reasonix", opencode: "opencode", zcode: "zcode",
       grokbuild: "grokbuild", openclaw: "openclaw", pi: "pi", hermes: "hermes",
-      kimi: "kimi",
+      kimi: "kimi", dsh: "dsh",
     };
     // 分页大小：sessions 路由按 offset/limit 切片（total 为过滤后总数）
     const PAGE_SIZE = 50;

--- a/lib/command.mjs
+++ b/lib/command.mjs
@@ -1,6 +1,6 @@
 // lib/command.mjs — REQ-42 /import 命令面
 //
-// 斜杠命令 `/import <source> <path>`（用户触发、不占模型轮次）：解析 source（13 个
+// 斜杠命令 `/import <source> <path>`（用户触发、不占模型轮次）：解析 source（14 个
 // 来源的短名 / 客户端来源 id / 工具全名三态）与 path（单文件或目录/数据根），复用
 // 面板同一套导入编排（importDiscoveryItem + IMPORT_SPECS——幂等 / 增量 / force /
 // 预算语义与 import_* 工具完全一致）。commands 是可选 host 服务（headless / CLI
@@ -28,9 +28,10 @@ const TOOL_FORMAT = {
   pi: 'pi', import_pi: 'pi',
   hermes: 'hermes', import_hermes: 'hermes',
   kimi: 'kimi', import_kimi: 'kimi',
+  dsh: 'dsh', import_dsh: 'dsh',
 }
 
-const SOURCE_NAMES = 'claude/codex/chatgpt/cursor/gemini/reasonix/opencode/zcode/grokbuild/openclaw/pi/hermes/kimi'
+const SOURCE_NAMES = 'claude/codex/chatgpt/cursor/gemini/reasonix/opencode/zcode/grokbuild/openclaw/pi/hermes/kimi/dsh'
 
 // 把导入结果压成人类可读文本（对齐 import_* 工具 render 的语义：批量计数 +
 // 前 5 条失败/跳过明细；单文件按 status 区分）。

--- a/lib/convert/dsh.mjs
+++ b/lib/convert/dsh.mjs
@@ -1,0 +1,139 @@
+// lib/convert/dsh.mjs — DSH 自身会话日志（session.jsonl / session.jsonl.zstd）
+// → DSH 会话事件。DSH 事件日志本就是目标格式：保留对话核心事件并重排 seq，
+// 丢弃流式 chunk 与运行时安全/头状态（导入会话由新宿主重新生成这些状态）。
+import { mintSessionId } from './core.mjs'
+
+const DURABLE = new Set([
+  'turn/start',
+  'step/start',
+  'user/message',
+  'assistant/message',
+  'tool/call',
+  'tool/result',
+  'step/end',
+  'turn/end',
+  'session/title',
+])
+
+function safeText(blocks) {
+  for (const b of Array.isArray(blocks) ? blocks : []) {
+    if (b && b.type === 'text' && typeof b.text === 'string' && b.text.trim()) {
+      return b.text.trim().replace(/\s+/g, ' ').slice(0, 80)
+    }
+  }
+  return ''
+}
+
+export function convertDshJsonl(raw, args = {}) {
+  const lines = String(raw || '').split('\n')
+  const parsed = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+    try {
+      parsed.push({ line: i + 1, value: JSON.parse(line) })
+    } catch {
+      // DSH 日志尾部的流式行可能是完整 JSON；畸形行忽略并计入 skipped。
+      parsed.push({ line: i + 1, value: null })
+    }
+  }
+
+  const sessionRec = parsed.find((p) => p.value && p.value.type === 'session' && p.value.id)?.value || {}
+  const headerRec = parsed.find((p) => p.value && p.value.type === 'request/header' && p.value.data && p.value.data.header)?.value
+  const header = headerRec ? headerRec.data.header : null
+  const config = header && header.config && typeof header.config === 'object' ? header.config : {}
+
+  const sourceId = String(sessionRec.id || '')
+  const fileStem = String(args.sourcePath || '').split(/[\\/]/).pop() || ''
+  const idSlug = sourceId || fileStem.replace(/\.jsonl(?:\.zstd)?$/i, '')
+  const metaId = mintSessionId(idSlug)
+
+  const createdAt = Number.isFinite(sessionRec.createdAt)
+    ? sessionRec.createdAt
+    : (parsed.find((p) => p.value && typeof p.value.time === 'number')?.value?.time ?? Date.now())
+
+  const sourceEvents = []
+  const oldToNew = new Map()
+  let skipped = 0
+  for (const p of parsed) {
+    const ev = p.value
+    if (!ev || typeof ev !== 'object') continue
+    if (!DURABLE.has(ev.type)) continue
+    if (!Number.isFinite(ev.seq)) continue
+    const data = ev.data && typeof ev.data === 'object' ? ev.data : {}
+    const next = {
+      type: ev.type,
+      seq: sourceEvents.length,
+      time: Number.isFinite(ev.time) ? ev.time : createdAt,
+      data,
+    }
+    if (typeof ev.surfaceOp === 'string') next.surfaceOp = ev.surfaceOp
+    oldToNew.set(ev.seq, next.seq)
+    sourceEvents.push(next)
+  }
+
+  // sourceEventSeqs 重映射到新 seq（指向日志内部事件）。
+  for (const ev of sourceEvents) {
+    if (Array.isArray(ev.sourceEventSeqs)) {
+      ev.sourceEventSeqs = ev.sourceEventSeqs.map((s) => (oldToNew.has(s) ? oldToNew.get(s) : s))
+    }
+  }
+
+  const titleEvent = [...sourceEvents].reverse().find((e) => e.type === 'session/title' && e.data && typeof e.data.title === 'string')
+  const title = titleEvent ? String(titleEvent.data.title) : (() => {
+    const u = sourceEvents.find((e) => e.type === 'user/message' && e.data && Array.isArray(e.data.content))
+    return u ? safeText(u.data.content) : ''
+  })()
+
+  const model = (() => {
+    if (typeof config.model === 'string') return config.model
+    const a = [...sourceEvents].reverse().find((e) => e.type === 'assistant/message' && e.data && e.data.message && e.data.message.source && typeof e.data.message.source.model === 'string')
+    return a ? a.data.message.source.model : undefined
+  })()
+  const provider = (() => {
+    if (typeof config.provider === 'string') return config.provider
+    const a = [...sourceEvents].reverse().find((e) => e.type === 'assistant/message' && e.data && e.data.message && e.data.message.source && typeof e.data.message.source.provider === 'string')
+    return a ? a.data.message.source.provider : 'dsh'
+  })()
+
+  const turnCount = sourceEvents.filter((e) => e.type === 'turn/start').length
+  const turns = new Array(turnCount)
+  const messages = sourceEvents.filter((e) => e.type === 'user/message' || e.type === 'assistant/message' || e.type === 'tool/result').length
+  const toolCalls = sourceEvents.filter((e) => e.type === 'tool/call').length
+
+  const events = []
+  if (sourceEvents.length > 0) {
+    events.push({
+      type: 'session/imported',
+      seq: 0,
+      time: createdAt,
+      ignorable: true,
+      data: {
+        tool: 'import_dsh',
+        sourceId: sourceId || idSlug,
+        sourcePath: args.sourcePath,
+        importedAt: Date.now(),
+      },
+    })
+  }
+  for (const ev of sourceEvents) {
+    events.push({ ...ev, seq: ev.seq + 1 })
+  }
+
+  return {
+    meta: {
+      id: metaId,
+      sourceId: sourceId || idSlug,
+      cwd: typeof sessionRec.cwd === 'string' ? sessionRec.cwd : undefined,
+      createdAt,
+      provider,
+      model,
+    },
+    events,
+    turns,
+    title,
+    messages,
+    toolCalls,
+    skipped,
+  }
+}

--- a/lib/convert/local-jsonl.mjs
+++ b/lib/convert/local-jsonl.mjs
@@ -1,0 +1,74 @@
+// lib/convert/local-jsonl.mjs — 本地 JSONL 会话文件的格式自动识别入口。
+// 输入路径可为任意 .jsonl；按路径特征排序候选后逐个尝试各源转换器，
+// 取第一个能产出 meta 且含轮次/事件的转换结果。`format` 入参可跳过探测。
+import { convertDshJsonl } from './dsh.mjs'
+import { convertClaudeJsonl } from './claude.mjs'
+import { convertCodexJsonl } from './codex.mjs'
+import { convertCursorJsonl } from './cursor.mjs'
+import { convertReasonixJsonl } from './reasonix.mjs'
+import { convertPiJsonl } from './pi.mjs'
+import { convertOpenclawJson } from './openclaw.mjs'
+import { convertHermesJson } from './hermes.mjs'
+
+export const LOCAL_JSONL_FORMATS = ['dsh', 'claude', 'codex', 'cursor', 'reasonix', 'pi', 'openclaw', 'hermes']
+
+const CONVERTERS = {
+  dsh: convertDshJsonl,
+  claude: convertClaudeJsonl,
+  codex: convertCodexJsonl,
+  cursor: convertCursorJsonl,
+  reasonix: convertReasonixJsonl,
+  pi: convertPiJsonl,
+  openclaw: convertOpenclawJson,
+  hermes: convertHermesJson,
+}
+
+// 路径特征只用于调整候选顺序，最终仍以转换结果能否产出会话为准。
+function pathPriority(sourcePath) {
+  const lower = String(sourcePath || '').toLowerCase()
+  if (/\/session\.jsonl$/.test(lower)) return ['dsh']
+  if (/\bagent-transcripts\b/.test(lower)) return ['cursor']
+  if (/(^|[\\/])rollout-/.test(lower)) return ['codex']
+  if (/(^|[\\/])(desktop|subagent)-/.test(lower)) return ['reasonix']
+  if (/\.pi[\\/]agent[\\/]sessions[\\/]/.test(lower)) return ['pi']
+  if (/\bagents\b.*\bsessions\b/.test(lower)) return ['openclaw']
+  if (/\.hermes[\\/]/.test(lower)) return ['hermes']
+  if (/\.claude[\\/]/.test(lower)) return ['claude']
+  return LOCAL_JSONL_FORMATS
+}
+
+function orderedFormats(args) {
+  const requested = typeof args.format === 'string' && CONVERTERS[args.format] ? [args.format] : []
+  return [...new Set([...requested, ...pathPriority(args.sourcePath)])]
+}
+
+export function convertLocalJsonl(raw, args = {}) {
+  let firstFailure = null
+  for (const format of orderedFormats(args)) {
+    try {
+      const out = CONVERTERS[format](raw, { ...args, sourcePath: args.sourcePath })
+      const hasContent = out && out.meta
+        && ((Array.isArray(out.turns) && out.turns.length > 0)
+          || (Array.isArray(out.events) && out.events.length > 0))
+      if (hasContent) {
+        out.detectedFormat = format
+        return out
+      }
+      if (!firstFailure) firstFailure = out
+    } catch (err) {
+      if (!firstFailure) {
+        firstFailure = { error: err && err.message ? err.message : String(err), meta: null, events: [], turns: [], messages: 0, toolCalls: 0, skipped: 0 }
+      }
+    }
+  }
+  if (firstFailure) return firstFailure
+  return {
+    meta: null,
+    events: [],
+    turns: [],
+    messages: 0,
+    toolCalls: 0,
+    skipped: 0,
+    skipReason: 'unrecognized local JSONL transcript',
+  }
+}

--- a/lib/discovery.mjs
+++ b/lib/discovery.mjs
@@ -51,10 +51,11 @@ import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, open, readFile, rename, rm } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
 
 export const FORMATS = [
   'claude', 'codex', 'cursor', 'gemini', 'reasonix', 'opencode',
-  'zcode', 'grokbuild', 'openclaw', 'pi', 'hermes', 'kimi', 'chatgpt',
+  'zcode', 'grokbuild', 'openclaw', 'pi', 'hermes', 'kimi', 'chatgpt', 'dsh',
 ]
 
 export const SCAN_TTL_MS = 30000
@@ -79,6 +80,7 @@ export function defaultRoots({ home = homedir() } = {}) {
     hermes: join(home, '.hermes'),
     kimi: join(home, '.kimi', 'sessions'),
     chatgpt: null,
+    dsh: join(home, '.dsh', 'sessions'),
   }
 }
 
@@ -379,6 +381,16 @@ export function layoutProject(sourcePath, format) {
     case 'gemini': {
       const m = p.match(/\/history\/([^/]+)\/chats\//)
       return m ? m[1] : null
+    }
+    case 'dsh': {
+      // $DSH_HOME/sessions/<encoded-workspace>/<session-id>/session.jsonl(.zstd)
+      const m = p.match(/\/sessions\/([^/]+)\/[^/]+\/session\.jsonl(?:\.zstd)?$/i)
+      if (!m) return null
+      try {
+        return decodeURIComponent(m[1].replace(/~/g, '%'))
+      } catch {
+        return m[1]
+      }
     }
     default:
       return null
@@ -975,6 +987,48 @@ async function scanChatgpt(host, target, bm) {
   })
 }
 
+// dsh：$DSH_HOME/sessions/<encoded-workspace>/<session-id>/session.jsonl(.zstd)。
+// .zstd 用系统 zstd 解压后取头；session 首行提供 id/cwd/createdAt，session/title
+// 事件优先作标题，否则回退首条真实 user 文本。
+async function scanDsh(host, target, bm) {
+  const files = []
+  await walkFiles(host, target, files, (name) => /^session\.jsonl(?:\.zstd)?$/i.test(name))
+  const out = []
+  for (const file of files) {
+    const st = await host.stat(file.path)
+    if (!st) continue
+    const fp = { mtimeMs: st.mtimeMs, sizeBytes: st.size }
+    const entries = await probeSource(bm, 'dsh', file.path, fp, async () => {
+      let text
+      if (/\.zstd$/i.test(file.path)) {
+        try {
+          text = execFileSync('zstd', ['-dc', file.path], { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 })
+        } catch {
+          return []
+        }
+      } else {
+        text = await host.readText(file.path)
+      }
+      const recs = parseJsonlHead(text)
+      const sessionRec = recs.find((r) => r && r.type === 'session' && typeof r.id === 'string' && r.id)
+      if (!sessionRec) return []
+      const titleRec = [...recs].reverse().find((r) => r && r.type === 'session/title' && r.data && typeof r.data.title === 'string')
+      const title = titleRec
+        ? normalizeTitle(titleRec.data.title)
+        : firstUserTitle(recs, (r) => (r && r.type === 'user/message' && r.data && Array.isArray(r.data.content) ? contentText(r.data.content) : ''))
+      const messageCount = recs.filter((r) => r && (r.type === 'user/message' || r.type === 'assistant/message' || r.type === 'tool/result')).length
+      return [makeEntry({
+        format: 'dsh', sessionId: sessionRec.id, title,
+        project: projectFromRecord(sessionRec.cwd, () => layoutProject(file.path, 'dsh')),
+        createdAt: Number.isFinite(sessionRec.createdAt) ? sessionRec.createdAt : parseTimeValue(sessionRec.createdAt),
+        lastActiveAt: st.mtimeMs, messageCount, sourcePath: file.path,
+      })]
+    })
+    out.push(...entries)
+  }
+  return out
+}
+
 const SCANNERS = {
   claude: scanClaude,
   codex: scanCodex,
@@ -989,6 +1043,7 @@ const SCANNERS = {
   hermes: scanHermes,
   kimi: scanKimi,
   chatgpt: scanChatgpt,
+  dsh: scanDsh,
 }
 
 // 单格式扫描：单个数据根读取失败（权限/损坏）只跳过该格式，不拖垮整次发现
@@ -1009,6 +1064,7 @@ export async function scanFormat(host, format, target, bm) {
 // 探测，扫描器按结构自拒）。
 function fileFormatsForPath(path) {
   const lower = String(path).toLowerCase()
+  if (/\/session\.jsonl(?:\.zstd)?$/.test(lower)) return ['dsh']
   if (/\.jsonl$/i.test(lower)) {
     const fmts = []
     if (/\bagent-transcripts\b/.test(lower)) fmts.push('cursor')

--- a/lib/dsh.mjs
+++ b/lib/dsh.mjs
@@ -1,0 +1,35 @@
+// lib/dsh.mjs — DSH 自身会话日志（session.jsonl / session.jsonl.zstd）的读取
+// 与目录收集适配。DSH 落盘是 zstd 压缩 JSONL，fs.readText 不解压，因此这里用
+// 系统 zstd 二进制解压；无 zstd 时让错误自然上报到导入结果。
+import { execFileSync } from 'node:child_process'
+
+export function isDshSessionFile(name) {
+  return /^session\.jsonl(?:\.zstd)?$/i.test(String(name || ''))
+}
+
+export function dshPath(target) {
+  return target.displayPath || target.path || target
+}
+
+export async function readDshText(ctx, target) {
+  const path = dshPath(target)
+  if (/\.zstd$/i.test(path)) {
+    return execFileSync('zstd', ['-dc', path], {
+      encoding: 'utf8',
+      maxBuffer: 256 * 1024 * 1024,
+    })
+  }
+  return ctx.fs.readText(target)
+}
+
+// 递归收集目录下的 session.jsonl(.zstd)；跳过 events/conflicts/guardian 等伴生文件。
+export async function collectDshFiles(ctx, dirTarget, out, recursive) {
+  const entries = await ctx.fs.listDir(dirTarget)
+  for (const entry of entries) {
+    if (entry.type === 'directory') {
+      if (recursive) await collectDshFiles(ctx, entry.target, out, recursive)
+    } else if (entry.type === 'file' && isDshSessionFile(entry.name)) {
+      out.push(entry.target)
+    }
+  }
+}

--- a/lib/import-core.mjs
+++ b/lib/import-core.mjs
@@ -107,7 +107,7 @@ export async function runDecision(ctx, decision, registryDir, sourcePath, persis
 // 解析单个 transcript（REQ-24 状态机入口）：stat → registry 短路径判定 → 读取转换 →
 // decideSingle 决策落盘 → 归组。幂等键 = sourcePath（fs 服务归一化路径）。persisted
 // 可传入共享快照（批量模式），缺省按需取一次。
-export async function importTranscript(ctx, target, args, convert, { registryDir, persisted, fingerprintKeys = [] } = {}) {
+export async function importTranscript(ctx, target, args, convert, { registryDir, persisted, fingerprintKeys = [], readText } = {}) {
   const persistedSet = persisted ?? await listPersistedIds(ctx)
   const archivedIds = archivedSessionIds(ctx)
   const sourcePath = target.displayPath || ctx.fs.processPath(target)
@@ -136,7 +136,7 @@ export async function importTranscript(ctx, target, args, convert, { registryDir
     }
   }
 
-  const raw = await ctx.fs.readText(target)
+  const raw = readText ? await readText(ctx, target) : await ctx.fs.readText(target)
   const out = markTrimmedSource(convert(raw, { ...args, sourcePath }), args)
   // 无可导入内容（空文件 / 非目标格式 / 辅助 transcript）：计入 skipped，不落盘空会话
   if (!out.meta || (out.turns.length === 0 && out.events.length === 0)) {
@@ -199,7 +199,7 @@ export function batchItem(path, single) {
 // importTranscript 状态机，共享 persisted 快照与 registry 目录）。
 // deriveArgs(target) 允许按文件派生转换参数（可 async；Cursor 取文件名 composer id，
 // Reasonix 读同目录 meta.json 拿 workspace/summary）；collect 默认收集 .jsonl。
-export async function importDirectory(ctx, dirTarget, args, { convert, sourceLabel, deriveArgs, collect, registryDir, fingerprintKeys = [] }) {
+export async function importDirectory(ctx, dirTarget, args, { convert, sourceLabel, deriveArgs, collect, registryDir, fingerprintKeys = [], readText }) {
   const files = []
   const collector = collect || collectJsonlFiles
   await collector(ctx, dirTarget, files, args.recursive !== false)
@@ -215,7 +215,7 @@ export async function importDirectory(ctx, dirTarget, args, { convert, sourceLab
     try {
       const derived = deriveArgs ? await deriveArgs(target) : {}
       // 展开 args（含 REQ-37 预算 budget/budgetSource），deriveArgs 可覆盖
-      const single = await importTranscript(ctx, target, { ...args, ...derived, force: args.force === true }, convert, { registryDir, persisted, fingerprintKeys })
+      const single = await importTranscript(ctx, target, { ...args, ...derived, force: args.force === true }, convert, { registryDir, persisted, fingerprintKeys, readText })
       if (single.status === 'imported') imported++
       else if (single.status === 'appended') appended++
       else if (single.status === 'already-imported') alreadyImported++
@@ -262,14 +262,15 @@ export function previewEntry(out) {
 }
 
 // 标准单文件预览：readText + convert（与 importTranscript 同源），零副作用。
-export async function previewTranscript(ctx, target, args, convert) {
+export async function previewTranscript(ctx, target, args, convert, { readText } = {}) {
   const sourcePath = target.displayPath || ctx.fs.processPath(target)
-  const out = markTrimmedSource(convert(await ctx.fs.readText(target), { ...args, sourcePath }), args)
+  const raw = readText ? await readText(ctx, target) : await ctx.fs.readText(target)
+  const out = markTrimmedSource(convert(raw, { ...args, sourcePath }), args)
   return previewEntry(out)
 }
 
 // 标准目录预览：逐文件 readText + convert（与 importDirectory 同源），零副作用。
-export async function previewDirectory(ctx, dirTarget, args, { convert, deriveArgs, collect } = {}) {
+export async function previewDirectory(ctx, dirTarget, args, { convert, deriveArgs, collect, readText } = {}) {
   const files = []
   const collector = collect || collectJsonlFiles
   await collector(ctx, dirTarget, files, args.recursive !== false)
@@ -278,7 +279,8 @@ export async function previewDirectory(ctx, dirTarget, args, { convert, deriveAr
     const path = target.displayPath || ctx.fs.processPath(target)
     try {
       const derived = deriveArgs ? await deriveArgs(target) : {}
-      const out = markTrimmedSource(convert(await ctx.fs.readText(target), { ...args, ...derived, sourcePath: path }), args)
+      const raw = readText ? await readText(ctx, target) : await ctx.fs.readText(target)
+      const out = markTrimmedSource(convert(raw, { ...args, ...derived, sourcePath: path }), args)
       results.push({ path, ...previewEntry(out) })
     } catch (err) {
       results.push({ path, status: 'failed', error: String((err && err.message) || err) })

--- a/lib/panel.mjs
+++ b/lib/panel.mjs
@@ -38,6 +38,7 @@ const SOURCE_FORMAT = {
   pi: 'pi',
   hermes: 'hermes',
   kimi: 'kimi',
+  dsh: 'dsh',
 }
 
 // 单条发现条目导入：stat → 目录（dirSingle 判定单会话）/ 文件（alwaysBatch /

--- a/lib/toolkit.mjs
+++ b/lib/toolkit.mjs
@@ -20,15 +20,15 @@ import {
 export const IMPORT_SPECS = new Map()
 
 export function makeImportTool(ctx, spec) {
-  const { format, toolName, sourceLabel, convert, description, importFile, importDir, alwaysBatch, deriveArgs, collect, extraParameters, pathDescription, dropParameters, batchUnit = '文件', skippedNote, registryDir, fingerprintKeys = [], dirSingle, fileBatch, previewFile, previewDir } = spec
+  const { format, toolName, sourceLabel, convert, description, importFile, importDir, alwaysBatch, deriveArgs, collect, extraParameters, pathDescription, dropParameters, batchUnit = '文件', skippedNote, registryDir, fingerprintKeys = [], dirSingle, fileBatch, previewFile, previewDir, readText } = spec
   // REQ-41 Stage 2：带 format 的来源同时登记进 IMPORT_SPECS，供 POST /api-import/import
   // 路由复用同一套导入编排（面板导入与 import_* 工具行为完全一致）。
   if (format) IMPORT_SPECS.set(format, spec)
   const derive = deriveArgs || (async () => ({}))
-  const importSingle = importFile || ((c, t, a) => importTranscript(c, t, a, convert, { registryDir, fingerprintKeys }))
-  const importBatch = importDir || ((c, d, a) => importDirectory(c, d, a, { convert, sourceLabel, deriveArgs: derive, collect, registryDir, fingerprintKeys }))
-  const previewSingle = previewFile || ((c, t, a) => previewTranscript(c, t, a, convert))
-  const previewBatch = previewDir || ((c, d, a) => previewDirectory(c, d, a, { convert, deriveArgs: derive, collect }))
+  const importSingle = importFile || ((c, t, a) => importTranscript(c, t, a, convert, { registryDir, fingerprintKeys, readText }))
+  const importBatch = importDir || ((c, d, a) => importDirectory(c, d, a, { convert, sourceLabel, deriveArgs: derive, collect, registryDir, fingerprintKeys, readText }))
+  const previewSingle = previewFile || ((c, t, a) => previewTranscript(c, t, a, convert, { readText }))
+  const previewBatch = previewDir || ((c, d, a) => previewDirectory(c, d, a, { convert, deriveArgs: derive, collect, readText }))
   // 增量续写语义（REQ-24）：与各工具 description 里的「幂等跳过」表述互补
   const descriptionSuffix = ' 重复导入已导入的源文件会增量续写新增轮次（源文件未变则跳过）；force:true 以新 id 另存完整副本。'
   return defineTool({

--- a/lib/tools.mjs
+++ b/lib/tools.mjs
@@ -1,4 +1,4 @@
-// lib/tools.mjs — 18 个工具的注册（13 个 import_* + export_claude + sync_to_claude
+// lib/tools.mjs — 20 个工具的注册（15 个 import_* + export_claude + sync_to_claude
 // + list_imported_sessions + retract_import + scan_discover）
 //
 // apply 入口只做两件事：本文件的 registerTools（工具注册）与 lib/panel.mjs 的
@@ -13,7 +13,7 @@ import {
   convertClaudeJsonl, convertCodexJsonl, convertChatgptJson, convertCursorJsonl,
   convertGeminiJson, convertReasonixJsonl, convertPiJsonl, convertOpencodeJson,
   convertZcodeJson, convertGrokbuildJson, convertOpenclawJson, convertHermesJson,
-  convertKimiWire, convertDshJsonl,
+  convertKimiWire, convertDshJsonl, convertLocalJsonl,
 } from '../convert.mjs'
 import { openclawDisplayNames } from './convert/openclaw.mjs'
 import { markTrimmedSource } from './budget.mjs'
@@ -426,6 +426,28 @@ export function registerTools(ctx, registryDir) {
       '从 DeepSeek Harness（DSH）自身的会话日志导入历史对话为可继续的 DSH 会话。' +
       'path 可以是单个 session.jsonl 或 session.jsonl.zstd 文件，也可以是包含多个会话日志的目录（默认扫描 ~/.dsh/sessions）。' +
       '保留 turn/step/user/assistant/tool 核心事件并重排 seq；流式 chunk 与运行时状态事件不导入；' +
+      '重复导入同一会话会幂等跳过。返回新会话 id（或批量统计）与明细。',
+  }))
+  // 本地 JSONL 会话文件：任意 .jsonl 路径，转换器按路径特征 + 内容自动识别
+  // dsh / claude / codex / cursor / reasonix / pi / openclaw / hermes，也可用
+  // format 参数强制指定。不是第 15 个「来源」——面板来源列表仍保持 14 个。
+  ctx.tools.register(makeImportTool(ctx, {
+    toolName: 'import_local_jsonl',
+    sourceLabel: 'Local JSONL',
+    convert: convertLocalJsonl,
+    registryDir,
+    pathDescription: '本地会话 JSONL 文件的路径，或包含多个 .jsonl 的目录路径。',
+    extraParameters: {
+      format: {
+        type: 'string',
+        enum: ['dsh', 'claude', 'codex', 'cursor', 'reasonix', 'pi', 'openclaw', 'hermes'],
+        description: '可选：强制按指定格式解析；缺省自动识别（路径特征 + 首条有效会话结构）。',
+      },
+    },
+    description:
+      '从本地任意 JSONL 会话文件导入历史对话为可继续的 DSH 会话。' +
+      '自动识别 dsh / claude / codex / cursor / reasonix / pi / openclaw / hermes 格式，' +
+      '识别失败时可用 format 参数强制指定；目录模式递归扫描 .jsonl，每个文件独立导入。' +
       '重复导入同一会话会幂等跳过。返回新会话 id（或批量统计）与明细。',
   }))
   // REQ-16 反向导出：第 15 个工具，独立注册（导出流程与导入状态机完全不同）。

--- a/lib/tools.mjs
+++ b/lib/tools.mjs
@@ -13,7 +13,7 @@ import {
   convertClaudeJsonl, convertCodexJsonl, convertChatgptJson, convertCursorJsonl,
   convertGeminiJson, convertReasonixJsonl, convertPiJsonl, convertOpencodeJson,
   convertZcodeJson, convertGrokbuildJson, convertOpenclawJson, convertHermesJson,
-  convertKimiWire,
+  convertKimiWire, convertDshJsonl,
 } from '../convert.mjs'
 import { openclawDisplayNames } from './convert/openclaw.mjs'
 import { markTrimmedSource } from './budget.mjs'
@@ -38,6 +38,7 @@ import {
 import { exportClaudeSession } from './export-tool.mjs'
 import { listImportedSessions, retractImport } from './retract.mjs'
 import { runScanDiscover } from './discovery-host.mjs'
+import { readDshText, collectDshFiles } from './dsh.mjs'
 
 export function registerTools(ctx, registryDir) {
   // 声明 TOOL_RUNTIME_SCHEDULER 命名导入：一旦解析到旧副本 dsh-tools@0.0.1-rc.1
@@ -409,7 +410,25 @@ export function registerTools(ctx, registryDir) {
       '标题取 state.json custom_title > 首问；重复导入同一会话会幂等跳过。' +
       '返回新会话 id（或批量统计）与明细。',
   }))
-  // REQ-16 反向导出：第 14 个工具，独立注册（导出流程与导入状态机完全不同）。
+  // dsh 源（第 14 个导入源）：DSH 自身会话日志
+  // $DSH_HOME/sessions/<encoded-workspace>/<session-id>/session.jsonl(.zstd)。
+  // .zstd 由系统 zstd 解压后走同一转换器；目录递归收集 session.jsonl(.zstd)。
+  ctx.tools.register(makeImportTool(ctx, {
+    format: 'dsh',
+    toolName: 'import_dsh',
+    sourceLabel: 'DSH',
+    convert: convertDshJsonl,
+    readText: readDshText,
+    collect: collectDshFiles,
+    registryDir,
+    pathDescription: 'DSH 会话日志 session.jsonl / session.jsonl.zstd 的文件路径，或包含这些文件的会话目录（默认根 ~/.dsh/sessions，目录递归收集）。',
+    description:
+      '从 DeepSeek Harness（DSH）自身的会话日志导入历史对话为可继续的 DSH 会话。' +
+      'path 可以是单个 session.jsonl 或 session.jsonl.zstd 文件，也可以是包含多个会话日志的目录（默认扫描 ~/.dsh/sessions）。' +
+      '保留 turn/step/user/assistant/tool 核心事件并重排 seq；流式 chunk 与运行时状态事件不导入；' +
+      '重复导入同一会话会幂等跳过。返回新会话 id（或批量统计）与明细。',
+  }))
+  // REQ-16 反向导出：第 15 个工具，独立注册（导出流程与导入状态机完全不同）。
   ctx.tools.register(defineTool({
     name: 'export_claude',
     description:
@@ -700,12 +719,12 @@ export function registerTools(ctx, registryDir) {
   ctx.tools.register(defineTool({
     name: 'scan_discover',
     description:
-      '只读扫描本机 13 种外部聊天记录格式的已知数据根（Claude Code / Codex / Cursor / ' +
+      '只读扫描本机 14 种外部聊天记录格式的已知数据根（Claude Code / Codex / Cursor / ' +
       'Gemini CLI / Reasonix / opencode / zcode / Grok Build / OpenClaw / Pi Coding Agent / ' +
-      'Hermes / Kimi CLI / ChatGPT 导出），返回结构化会话索引（format / sessionId / title / project / ' +
+      'Hermes / Kimi CLI / ChatGPT 导出 / DSH 会话日志），返回结构化会话索引（format / sessionId / title / project / ' +
       'createdAt / lastActiveAt / messageCount / sourcePath / importStatus），供批导入前预览。' +
       'path 可选：给定时在该根下按格式探测（目录或单文件）；缺省扫全部格式的默认数据根。' +
-      'format 可选：只扫指定格式（chatgpt 无自动根，需 path 显式指向 conversations.json）。' +
+      'format 可选：只扫指定格式（chatgpt 无自动根，需 path 显式指向 conversations.json；dsh 默认根为 ~/.dsh/sessions）。' +
       'query 可选：按标题 / 项目 / 路径子串过滤（忽略大小写）。' +
       '进程内 30s TTL 缓存：同 key 30 秒内重复扫描直接命中，不重读源文件。' +
       '持久化 mtime/size 书签（scan-cache.json）：跨进程重启后未变文件免重扫。' +

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lib/discovery-host.mjs",
     "lib/panel.mjs",
     "lib/tools.mjs",
+    "lib/dsh.mjs",
     "lib/convert",
     "lib/export",
     "lib/hermes.mjs",

--- a/test/discovery.test.mjs
+++ b/test/discovery.test.mjs
@@ -538,7 +538,7 @@ test('isInjectedTitle / normalizeTitle / layoutProject 纯函数', () => {
   assert.equal(layoutProject('/home/u/.cursor/projects/slug-c/agent-transcripts/abc/abc.jsonl', 'cursor'), 'slug-c')
 })
 
-test('FORMATS 与工具 schema enum 一致（13 种）', () => {
-  assert.equal(FORMATS.length, 13)
-  assert.deepEqual([...FORMATS].sort(), ['chatgpt', 'claude', 'codex', 'cursor', 'gemini', 'grokbuild', 'hermes', 'kimi', 'openclaw', 'opencode', 'pi', 'reasonix', 'zcode'])
+test('FORMATS 与工具 schema enum 一致（14 种）', () => {
+  assert.equal(FORMATS.length, 14)
+  assert.deepEqual([...FORMATS].sort(), ['chatgpt', 'claude', 'codex', 'cursor', 'dsh', 'gemini', 'grokbuild', 'hermes', 'kimi', 'openclaw', 'opencode', 'pi', 'reasonix', 'zcode'])
 })

--- a/test/dsh.test.mjs
+++ b/test/dsh.test.mjs
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, stat, readFile, readdir, open, rm } from 'node:fs/promises'
+import { Buffer } from 'node:buffer'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { convertDshJsonl } from '../lib/convert/dsh.mjs'
+import { discoverSessions } from '../lib/discovery.mjs'
+
+const SESSION_LINES = [
+  { type: 'session', id: 'session-dsh-test', cwd: '/tmp/proj', createdAt: 1700000000000 },
+  { type: 'turn/start', seq: 0, time: 1700000000000, data: { turn: 1 } },
+  { type: 'step/start', seq: 1, time: 1700000000000, data: { turn: 1, step: 1 } },
+  { type: 'user/message', seq: 2, time: 1700000000000, surfaceOp: 'append', data: { role: 'user', content: [{ type: 'text', text: '你好' }] } },
+  { type: 'assistant/message', seq: 3, time: 1700000000000, surfaceOp: 'append', data: { turn: 1, step: 1, message: { role: 'assistant', content: [{ type: 'text', text: '回复' }] } } },
+  { type: 'step/end', seq: 4, time: 1700000000000, data: { turn: 1, step: 1 } },
+  { type: 'turn/end', seq: 5, time: 1700000000000, data: { turn: 1 } },
+  { type: 'session/title', seq: 6, time: 1700000000000, data: { title: 'DSH 导入测试' } },
+]
+const RAW = SESSION_LINES.map((l) => JSON.stringify(l)).join('\n')
+
+test('convertDshJsonl 保留核心事件并重排 seq', () => {
+  const out = convertDshJsonl(RAW, { sourcePath: '/tmp/proj/session.jsonl' })
+  assert.equal(out.meta.id, 'import-session-dsh-test')
+  assert.equal(out.meta.cwd, '/tmp/proj')
+  assert.equal(out.turns.length, 1)
+  assert.equal(out.title, 'DSH 导入测试')
+  assert.equal(out.messages, 2)
+  assert.equal(out.toolCalls, 0)
+  assert.equal(out.events[0].type, 'session/imported')
+  assert.equal(out.events[0].data.tool, 'import_dsh')
+  assert.ok(out.events.every((e) => Number.isFinite(e.seq)))
+  assert.deepEqual(out.events.slice(1, 3).map((e) => e.type), ['turn/start', 'step/start'])
+})
+
+test('discoverSessions format=dsh 发现 session.jsonl 会话', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-import-test-'))
+  const dir = join(root, 'sessions', 'encoded', 'session-dsh-test')
+  await mkdir(dir, { recursive: true })
+  const file = join(dir, 'session.jsonl')
+  await writeFile(file, RAW + '\n')
+  const host = {
+    async stat(path) {
+      try {
+        const s = await stat(path)
+        return { type: s.isDirectory() ? 'directory' : 'file', size: s.size, mtimeMs: s.mtimeMs }
+      } catch {
+        return null
+      }
+    },
+    async readHead(path, bytes) {
+      const fh = await open(path, 'r')
+      try {
+        const b = Buffer.alloc(Math.min(bytes, 64 * 1024))
+        const { bytesRead } = await fh.read(b, 0, b.length, 0)
+        return b.subarray(0, bytesRead).toString('utf8')
+      } finally {
+        await fh.close()
+      }
+    },
+    async readText(path) {
+      try { return await readFile(path, 'utf8') } catch { return null }
+    },
+    async readDir(path) {
+      const entries = await readdir(path, { withFileTypes: true })
+      return entries.map((e) => ({ name: e.name, type: e.isDirectory() ? 'directory' : 'file', path: join(path, e.name) }))
+    },
+    async readSessions() { return [] },
+  }
+  try {
+    const found = await discoverSessions({ format: 'dsh', path: join(root, 'sessions'), host, imports: {} })
+    assert.equal(found.total, 1)
+    assert.equal(found.sessions[0].format, 'dsh')
+    assert.equal(found.sessions[0].sessionId, 'session-dsh-test')
+    assert.equal(found.sessions[0].title, 'DSH 导入测试')
+    assert.equal(found.sessions[0].messageCount, 2)
+    assert.equal(found.sessions[0].sourcePath, file)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -258,12 +258,12 @@ function assertImportedMarker(events, { tool, sourceId, sourcePath }) {
   assert.ok(ev.data.importedAt > 0)
 }
 
-test('apply 注册十八个工具（13 导入 + scan_discover + export_claude + sync_to_claude + REQ-33 识别/撤回）', () => {
+test('apply 注册十九个工具（14 导入 + scan_discover + export_claude + sync_to_claude + REQ-33 识别/撤回）', () => {
   const { ctx, registered } = makeCtx({})
   apply(ctx)
-  assert.equal(registered.length, 18)
+  assert.equal(registered.length, 19)
   const names = registered.map((d) => d.name).sort()
-  assert.deepEqual(names, ['export_claude', 'import_chatgpt', 'import_claude', 'import_codex', 'import_cursor', 'import_gemini', 'import_grokbuild', 'import_hermes', 'import_kimi', 'import_openclaw', 'import_opencode', 'import_pi', 'import_reasonix', 'import_zcode', 'list_imported_sessions', 'retract_import', 'scan_discover', 'sync_to_claude'])
+  assert.deepEqual(names, ['export_claude', 'import_chatgpt', 'import_claude', 'import_codex', 'import_cursor', 'import_dsh', 'import_gemini', 'import_grokbuild', 'import_hermes', 'import_kimi', 'import_openclaw', 'import_opencode', 'import_pi', 'import_reasonix', 'import_zcode', 'list_imported_sessions', 'retract_import', 'scan_discover', 'sync_to_claude'])
   for (const def of registered) {
     if (['export_claude', 'sync_to_claude', 'scan_discover', 'list_imported_sessions', 'retract_import'].includes(def.name)) {
       // 导出 / 写回 / 发现 / 识别 / 撤回工具：单对象输出 schema（非 oneOf）
@@ -3165,7 +3165,7 @@ test('REQ-17 预览 → 正式导入：去掉 preview 后字段口径一致、�
 
 // ---- REQ-41 被动会话发现（Browser 面板数据源路由） ----
 
-test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-import/import，kind exact），工具计数不变', () => {
+test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-import/import，kind exact），工具计数不变（19 个）', () => {
   const { ctx, webRoutes, registered } = makeCtx({})
   apply(ctx)
   const sessions = webRoutes.find((r) => r.path === '/api-import/sessions')
@@ -3176,16 +3176,16 @@ test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-im
   assert.equal(imp.kind, 'exact')
   assert.equal(typeof sessions.handler, 'function')
   assert.equal(typeof imp.handler, 'function')
-  // 只加路由，不加工具：13 导入 + scan/export/sync/list/retract = 18，注册数不变
-  assert.equal(registered.length, 18)
+  // 只加路由，不加工具：14 导入 + scan/export/sync/list/retract = 19，注册数不变
+  assert.equal(registered.length, 19)
 })
 
-test('REQ-41 webServer 可选：headless（无 webServer）apply 不抛错、18 工具照常注册、无路由', () => {
+test('REQ-41 webServer 可选：headless（无 webServer）apply 不抛错、19 工具照常注册、无路由', () => {
   const { ctx, webRoutes, registered } = makeCtx({}, { noWebServer: true })
   apply(ctx)
   // 缺 webServer 只是不注册面板路由，导入工具不受影响（CI headless 冒烟场景）
   assert.equal(webRoutes.length, 0)
-  assert.equal(registered.length, 18)
+  assert.equal(registered.length, 19)
 })
 
 test('REQ-41 /api-import/sessions handler：合成夹具经 discoverSessions 返回会话、未知来源 400', async () => {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -258,12 +258,12 @@ function assertImportedMarker(events, { tool, sourceId, sourcePath }) {
   assert.ok(ev.data.importedAt > 0)
 }
 
-test('apply 注册十九个工具（14 导入 + scan_discover + export_claude + sync_to_claude + REQ-33 识别/撤回）', () => {
+test('apply 注册二十个工具（14 来源 + import_local_jsonl + scan_discover + export_claude + sync_to_claude + REQ-33 识别/撤回）', () => {
   const { ctx, registered } = makeCtx({})
   apply(ctx)
-  assert.equal(registered.length, 19)
+  assert.equal(registered.length, 20)
   const names = registered.map((d) => d.name).sort()
-  assert.deepEqual(names, ['export_claude', 'import_chatgpt', 'import_claude', 'import_codex', 'import_cursor', 'import_dsh', 'import_gemini', 'import_grokbuild', 'import_hermes', 'import_kimi', 'import_openclaw', 'import_opencode', 'import_pi', 'import_reasonix', 'import_zcode', 'list_imported_sessions', 'retract_import', 'scan_discover', 'sync_to_claude'])
+  assert.deepEqual(names, ['export_claude', 'import_chatgpt', 'import_claude', 'import_codex', 'import_cursor', 'import_dsh', 'import_gemini', 'import_grokbuild', 'import_hermes', 'import_kimi', 'import_local_jsonl', 'import_openclaw', 'import_opencode', 'import_pi', 'import_reasonix', 'import_zcode', 'list_imported_sessions', 'retract_import', 'scan_discover', 'sync_to_claude'])
   for (const def of registered) {
     if (['export_claude', 'sync_to_claude', 'scan_discover', 'list_imported_sessions', 'retract_import'].includes(def.name)) {
       // 导出 / 写回 / 发现 / 识别 / 撤回工具：单对象输出 schema（非 oneOf）
@@ -3165,7 +3165,7 @@ test('REQ-17 预览 → 正式导入：去掉 preview 后字段口径一致、�
 
 // ---- REQ-41 被动会话发现（Browser 面板数据源路由） ----
 
-test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-import/import，kind exact），工具计数不变（19 个）', () => {
+test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-import/import，kind exact），工具计数不变（20 个）', () => {
   const { ctx, webRoutes, registered } = makeCtx({})
   apply(ctx)
   const sessions = webRoutes.find((r) => r.path === '/api-import/sessions')
@@ -3176,16 +3176,16 @@ test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-im
   assert.equal(imp.kind, 'exact')
   assert.equal(typeof sessions.handler, 'function')
   assert.equal(typeof imp.handler, 'function')
-  // 只加路由，不加工具：14 导入 + scan/export/sync/list/retract = 19，注册数不变
-  assert.equal(registered.length, 19)
+  // 只加路由，不加工具：15 导入 + scan/export/sync/list/retract = 20，注册数不变
+  assert.equal(registered.length, 20)
 })
 
-test('REQ-41 webServer 可选：headless（无 webServer）apply 不抛错、19 工具照常注册、无路由', () => {
+test('REQ-41 webServer 可选：headless（无 webServer）apply 不抛错、20 工具照常注册、无路由', () => {
   const { ctx, webRoutes, registered } = makeCtx({}, { noWebServer: true })
   apply(ctx)
   // 缺 webServer 只是不注册面板路由，导入工具不受影响（CI headless 冒烟场景）
   assert.equal(webRoutes.length, 0)
-  assert.equal(registered.length, 19)
+  assert.equal(registered.length, 20)
 })
 
 test('REQ-41 /api-import/sessions handler：合成夹具经 discoverSessions 返回会话、未知来源 400', async () => {

--- a/test/local-jsonl.test.mjs
+++ b/test/local-jsonl.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { convertLocalJsonl } from '../lib/convert/local-jsonl.mjs'
+
+const DSH_RAW = [
+  { type: 'session', id: 'session-local', cwd: '/tmp/proj', createdAt: 1700000000000 },
+  { type: 'turn/start', seq: 0, time: 1700000000000, data: { turn: 1 } },
+  { type: 'user/message', seq: 1, time: 1700000000000, surfaceOp: 'append', data: { role: 'user', content: [{ type: 'text', text: '本地文件' }] } },
+  { type: 'assistant/message', seq: 2, time: 1700000000000, surfaceOp: 'append', data: { turn: 1, step: 1, message: { role: 'assistant', content: [{ type: 'text', text: '回复' }] } } },
+  { type: 'turn/end', seq: 3, time: 1700000000000, data: { turn: 1 } },
+].map((l) => JSON.stringify(l)).join('\n')
+
+test('import_local_jsonl 自动识别 DSH 会话日志', () => {
+  const out = convertLocalJsonl(DSH_RAW, { sourcePath: '/tmp/download/session.jsonl' })
+  assert.equal(out.detectedFormat, 'dsh')
+  assert.equal(out.meta.id, 'import-session-local')
+  assert.equal(out.turns.length, 1)
+})
+
+test('import_local_jsonl 自动识别 Codex rollout', async () => {
+  const raw = await readFile(new URL('./fixtures/codex-simple.jsonl', import.meta.url), 'utf8')
+  const out = convertLocalJsonl(raw, { sourcePath: '/home/u/.codex/sessions/2026/01/01/rollout-test.jsonl' })
+  assert.equal(out.detectedFormat, 'codex')
+  assert.ok(out.meta && out.meta.id)
+})
+
+test('import_local_jsonl 自动识别 Cursor transcript', async () => {
+  const raw = await readFile(new URL('./fixtures/cursor-simple.jsonl', import.meta.url), 'utf8')
+  const out = convertLocalJsonl(raw, { sourcePath: '/home/u/.cursor/projects/p/agent-transcripts/id/id.jsonl' })
+  assert.equal(out.detectedFormat, 'cursor')
+  assert.ok(out.turns.length > 0)
+})
+
+test('import_local_jsonl format 参数强制指定解析器', async () => {
+  const raw = await readFile(new URL('./fixtures/codex-simple.jsonl', import.meta.url), 'utf8')
+  const out = convertLocalJsonl(raw, { sourcePath: '/tmp/any-name.jsonl', format: 'codex' })
+  assert.equal(out.detectedFormat, 'codex')
+})


### PR DESCRIPTION
Three additions on top of upstream main:

1. **DSH session-log source (14th import source)** — `import_dsh` discovers and imports `session.jsonl` / `session.jsonl.zstd` under `~/.dsh/sessions` (zstd decompressed with the system `zstd` binary), keeps durable turn/step/user/assistant/tool events, renumbers `seq`, and is wired through `scan_discover` (`format: "dsh"`), the sidebar panel source filter and `/import dsh <path>`.
2. **Local JSONL session-file import** — `import_local_jsonl` accepts any local `.jsonl` file or directory and auto-detects `dsh` / `claude` / `codex` / `cursor` / `reasonix` / `pi` / `openclaw` / `hermes` (path hints order candidates; first converter that yields a session wins). An optional `format` parameter forces one parser.
3. **Panel upload button** — the import panel header gains "Upload Session Logs": pick local `.jsonl` files, they are uploaded in 640 KiB chunks to `POST /api-import/upload` (adaptive halving on `413`, suitable behind a 1 MiB reverse-proxy body limit) into the session workspace `.dsh-import-uploads/`, then imported through the `local-jsonl` auto-detect pipeline.

`readText`/`collect` are now injectable through `import-core` and `makeImportTool` so custom readers (zstd) and collectors can reuse the standard idempotent/incremental import state machine. Docs, CHANGELOG and test expectations updated; `npm test` 394/394 and `npm run check:linux` pass locally.