### PR TITLE
feat: two-way incremental sync and web control panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 index.mjs        插件入口（薄组合层，host 面）：只做组装——registerTools（lib/tools.mjs 注册 15 个
                  导入工具（14 个来源 + import_local_jsonl） + scan_discover + export_claude + sync_to_claude + list_imported_sessions +
                  retract_import）+ ctx.inject(['webServer']) 延迟挂载面板路由
-                 （POST /api-import/sessions 发现、POST /api-import/import 面板导入）
+                 （POST /api-import/sessions 发现、POST /api-import/import 面板导入、
+                 GET/POST /api-import/sync 双向增量控制台）
 lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯函数）：imports.mjs（幂等 registry）、
                  backfill.mjs（sync_to_claude 写回）、discovery.mjs（14 格式统一发现 + 30s TTL / 持久化
                  书签）、budget.mjs（REQ-37 预算解析链）、import-core.mjs（共享导入编排：importTranscript
@@ -18,7 +19,9 @@ lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯�
                  （chatgpt / grokbuild / hermes / kimi 编排 + opencode / zcode 等 dry-run 预览）、toolkit.mjs
                  （makeImportTool 工厂 + IMPORT_SPECS）、export-tool.mjs（export_claude 执行体）、
                  retract.mjs（REQ-33 识别/撤回）、discovery-host.mjs（scan_discover host 适配）、
-                 panel.mjs（REQ-41 面板路由）、client.js（Browser 侧 bundle，REQ-41：sidebar.footer.action
+                 panel.mjs（REQ-41 面板路由）、sync-config.mjs / sync-loop.mjs / sync-panel.mjs
+                 （双向增量：入站巡检 + DSH→Claude/Codex/Grok 写出 + 控制台路由）、
+                 client.js（Browser 侧 bundle，REQ-41：sidebar.footer.action
                  槽 → 按工作区分组的面板 + 单选/多选导入；文案注册到 "chat-import" ns 经
                  @deepseek-ai/dsh-client-locale 随 web 语言切换，缺失时降级内置 zh）、command.mjs
                  （REQ-42 /import 命令面：commands 可选服务延迟注册，复用 importDiscoveryItem）、
@@ -26,7 +29,7 @@ lib/             导入/同步驱动（按职责拆分，均消费 ctx、非纯�
                  per-project 记忆 + env 开关）、context-bridge.mjs（REQ-28 上下文桥接：Claude 的
                  memory/CLAUDE.md/skills 桥进 scoped systemPrompt/skills，默认关 env 开关）、opencode.mjs / zcode.mjs / hermes.mjs
                  （SQLite 读取，node:sqlite）、convert/（转换核心按源拆分）、export/（反向序列化按目标
-                 格式拆分，当前仅 claude.mjs）
+                 格式拆分：claude.mjs / codex.mjs / grokbuild.mjs）
 convert.mjs      转换核心 re-export shim（已按源拆到 lib/convert/{core,claude,codex,chatgpt,cursor,gemini,reasonix,opencode,zcode,grokbuild,openclaw,hermes,pi,kimi,dsh,local-jsonl}.mjs，纯函数、零 DSH 依赖、可独立单测）
 export.mjs       反向导出序列化器 re-export shim（实体在 lib/export/claude.mjs——DSH 会话日志 → Claude
                  Code JSONL，纯函数、零 DSH 依赖；`exports["./export.mjs"]` 子路径契约保持不变）
@@ -41,7 +44,7 @@ test/            convert 单测 + export 单测 + index mock 集成 + zcode 自�
 dev/             ❌ 本地工程面（gitignore，永不提交）：bin/（脚本：session.mjs 多会话认领 CLI、verify-*、totp）、hooks/（pre-push）、research/（竞品/方向调研）、HANDOFF.md、REQUIREMENTS.md、GROWTH.md、RELEASING.md、ORCHESTRATOR-PROMPT.md、TESTER-PROMPT.md、gh-pat.txt（凭据勿提交）；多会话协调靠 dsh-file-claim 插件
 ```
 
-- `package.json` 的 `files` 白名单就是 npm 发布面：`index.mjs`、`convert.mjs`、`export.mjs`、`lib/imports.mjs`、`lib/backfill.mjs`、`lib/client.js`、`lib/command.mjs`、`lib/context-bridge.mjs`、`lib/discovery.mjs`、`lib/budget.mjs`、`lib/import-core.mjs`、`lib/import-variants.mjs`、`lib/toolkit.mjs`、`lib/export-tool.mjs`、`lib/prompt-hint.mjs`、`lib/retract.mjs`、`lib/discovery-host.mjs`、`lib/panel.mjs`、`lib/tools.mjs`、`lib/dsh.mjs`、`lib/convert`、`lib/export`、`lib/hermes.mjs`、`lib/opencode.mjs`、`lib/zcode.mjs`、`cordis.patch.yml`、`README.md`、`README.zh-CN.md`、`CHANGELOG.md`、`assets/import.svg`、`LICENSE`。新增被 `index.mjs` import 或 README 引用的文件必须同步加进 `files`。
+- `package.json` 的 `files` 白名单就是 npm 发布面：`index.mjs`、`convert.mjs`、`export.mjs`、`lib/imports.mjs`、`lib/backfill.mjs`、`lib/client.js`、`lib/command.mjs`、`lib/context-bridge.mjs`、`lib/discovery.mjs`、`lib/budget.mjs`、`lib/import-core.mjs`、`lib/import-variants.mjs`、`lib/toolkit.mjs`、`lib/export-tool.mjs`、`lib/prompt-hint.mjs`、`lib/retract.mjs`、`lib/discovery-host.mjs`、`lib/panel.mjs`、`lib/sync-config.mjs`、`lib/sync-loop.mjs`、`lib/sync-panel.mjs`、`lib/tools.mjs`、`lib/dsh.mjs`、`lib/convert`、`lib/export`、`lib/hermes.mjs`、`lib/opencode.mjs`、`lib/zcode.mjs`、`cordis.patch.yml`、`README.md`、`README.zh-CN.md`、`CHANGELOG.md`、`assets/import.svg`、`LICENSE`。新增被 `index.mjs` import 或 README 引用的文件必须同步加进 `files`。
 - **永不提交**：`dev/`、`node_modules/`、`.prev-session*.jsonl`、`.dsh-file-claim/`（插件运行时目录）、真实用户 transcript（含敏感内容）、任何凭据/密钥。
 
 ## 命令
@@ -102,7 +105,7 @@ npm run check:linux   # 跨平台路径纪律静态检查（.github/scripts/chec
 ## 质量约定
 
 - 文件以**恰好一个**换行结尾；空 `catch` 必须说明吞掉什么且 `try` 只包一条语句；不注释代码里显而易见的事实。
-- 保持 `lib/convert/*` 与 `lib/export/*`（含根 shim `convert.mjs` / `export.mjs`）零依赖纯函数：任何 DSH 依赖只允许出现在 `index.mjs` 与 `lib/{imports,backfill,opencode,zcode,hermes,dsh,discovery,budget,import-core,import-variants,toolkit,export-tool,retract,discovery-host,panel,tools}.mjs`（即所有消费 ctx 的 host 面模块）。
+- 保持 `lib/convert/*` 与 `lib/export/*`（含根 shim `convert.mjs` / `export.mjs`）零依赖纯函数：任何 DSH 依赖只允许出现在 `index.mjs` 与 `lib/{imports,backfill,opencode,zcode,hermes,dsh,discovery,budget,import-core,import-variants,toolkit,export-tool,retract,discovery-host,panel,sync-config,sync-loop,sync-panel,tools}.mjs`（即所有消费 ctx 的 host 面模块）。
 - 测试描述行为而非背书正确性；fixtures 用合成数据，永不掺真实 transcript。
 - **跨平台路径纪律（防 CI 红，`npm run check:linux` 护栏）**：CI 在 Linux 跑 `npm test`，测试里的反斜杠合成路径经代码 `node:path` 运算在 posix 下行为不同（`join()` 产混合分隔符、`dirname('D:\…')` 返 `'.'`）。规则：mock 树查找（`stat`/`readText`/`listDir` 读树）必须做分隔符归一（复用 `index.test.mjs` makeCtx 的 `norm` + `lookup` 三态命中）；断言若比较 `node:path` 运算结果，期望值用同口径函数计算，绝不写死 `'X:\…'` 字面量；新增导入测试优先用真实临时目录（`mkdtemp`）。
 - 不写行内文档废话：注释写契约与上下文，不叙述控制流。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Release dates are the npm publish timestamps in Asia/Shanghai (UTC+8).
 
 ### Added
 
+- **Two-way incremental sync control panel** — sidebar panel gains a Sync tab
+  (`GET/POST /api-import/sync`). Optional inbound watch (Claude / Codex / Grok
+  new or grown sessions → DSH append) and outbound writeback (DSH complete
+  turns → Claude source file, or Codex / Grok copies). Both directions default
+  **off**; a timer starts only after the user enables a switch. Outbound
+  copies for native DSH sessions are tracked in `outbound.json` so inbound
+  scans skip them (no echo loop).
+
 - **`import_agents` (REQ-59, 14th tool)** — converts custom agents / mode
   prompts / skills from **pi** (`~/.pi/agent/{agents,prompts}/*.md`) and
   **opencode** (`~/.config/opencode/{agents,skill}/*.md`) into persistent DSH

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 Nwflower
+Copyright (c) 2026 Scarlett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Import 14 external agent conversation histories into DeepSeek Harness as full-fidelity, resumable sessions — and export / sync back to Claude Code.**
 
+This public fork ([AI-Scarlett/dsh-chat-import](https://github.com/AI-Scarlett/dsh-chat-import)) adds two-way incremental sync (Claude / Codex / Grok) and a Web control panel. Upstream: [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import).
+
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](#)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](README.zh-CN.md)
 
@@ -97,6 +99,12 @@ import_claude({ path: "~/.claude/projects" })
 ```
 
 **3. Resume** — refresh the session list once, open the imported session, and continue chatting — it resumes exactly where the source left off.
+
+**4. Two-way incremental sync (local fork)** — the sidebar **Import Sessions** panel now has a **Sync** tab:
+
+- **External → DSH**: periodically scan Claude / Codex / Grok for new or grown sessions and import incrementally (same idempotent append state machine).
+- **DSH → External**: write new complete DSH turns back. Imported sessions append to their source file; native DSH sessions get a copy under that agent's default root.
+- Both directions are **off by default**. Turn them on in the panel, or click **Sync now**. Config lives in `$DSH_HOME/dsh-chat-import/sync.json`.
 
 <details>
 <summary><b>Uninstall</b></summary>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **Import 14 external agent conversation histories into DeepSeek Harness as full-fidelity, resumable sessions — and export / sync back to Claude Code.**
 
-This public fork ([AI-Scarlett/dsh-chat-import](https://github.com/AI-Scarlett/dsh-chat-import)) adds two-way incremental sync (Claude / Codex / Grok) and a Web control panel. Upstream: [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import).
-
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](#)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,8 +4,6 @@
 
 **把 14 种外部 Agent 聊天历史全保真导入 DeepSeek Harness 为可继续（resume）会话——并可导出 / 同步回 Claude Code。**
 
-本公开 fork（[AI-Scarlett/dsh-chat-import](https://github.com/AI-Scarlett/dsh-chat-import)）增加了 Claude / Codex / Grok 双向增量同步与 Web 控制面板。上游：[Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)。
-
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](README.md)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](#)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,8 @@
 
 **把 14 种外部 Agent 聊天历史全保真导入 DeepSeek Harness 为可继续（resume）会话——并可导出 / 同步回 Claude Code。**
 
+本公开 fork（[AI-Scarlett/dsh-chat-import](https://github.com/AI-Scarlett/dsh-chat-import)）增加了 Claude / Codex / Grok 双向增量同步与 Web 控制面板。上游：[Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)。
+
 [![English](https://img.shields.io/badge/Language-English-blue?style=for-the-badge)](README.md)
 [![简体中文](https://img.shields.io/badge/Language-简体中文-blue?style=for-the-badge)](#)
 
@@ -97,6 +99,12 @@ import_claude({ path: "~/.claude/projects" })
 ```
 
 **3. 续聊** — 刷新一次会话列表，打开导入的会话，继续对话——它会从源记录停下的地方无缝接上。
+
+**4. 双向增量同步（本机二次开发）** — 侧边栏「导入会话」面板新增 **同步** 页：
+
+- **外部 → DSH**：按间隔巡检 Claude / Codex / Grok 的新增或增长会话，走既有幂等续写。
+- **DSH → 外部**：把 DSH 新增完整轮次写回对应 agent。导入源追加到原文件；原生 DSH 会话在该 agent 默认根下落一份副本。
+- 两个方向**默认关闭**，必须在面板里打开开关，或点「立即同步」。配置在 `$DSH_HOME/dsh-chat-import/sync.json`。
 
 <details>
 <summary><b>卸载</b></summary>

--- a/index.mjs
+++ b/index.mjs
@@ -28,6 +28,8 @@
 import { resolveRegistryDir } from './lib/imports.mjs'
 import { registerTools } from './lib/tools.mjs'
 import { registerPanelRoutes } from './lib/panel.mjs'
+import { registerSyncRoutes } from './lib/sync-panel.mjs'
+import { registerSyncLoop } from './lib/sync-loop.mjs'
 import { registerImportCommand } from './lib/command.mjs'
 import { registerSessionHint } from './lib/prompt-hint.mjs'
 import { registerContextBridge } from './lib/context-bridge.mjs'
@@ -52,7 +54,10 @@ function apply(ctx) {
   // webServer）时回调永不执行，12 个导入工具照常可用，apply 不因缺服务失败。
   ctx.inject(['webServer'], (webCtx) => {
     registerPanelRoutes(ctx, webCtx.webServer, registryDir)
+    registerSyncRoutes(ctx, webCtx.webServer, registryDir)
   })
+  // 双向增量默认同步关闭；打开控制面板开关后才启定时器。
+  registerSyncLoop(ctx, registryDir)
   // REQ-42 /import 命令面：commands 同样可选（headless / CLI 会话可能不挂载），
   // 服务可用时注册（不阻塞插件激活）。
   registerImportCommand(ctx)

--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,24 @@ window.__ModuleLoader__.load({
         "result.separator": "，",
         "result.done": "导入完成：{bits}",
         "result.nochange": "无变化",
+        "tab.import": "导入",
+        "tab.sync": "同步",
+        "sync.panel.title": "双向同步",
+        "sync.inbound": "外部 → DSH",
+        "sync.outbound": "DSH → 外部",
+        "sync.inbound.hint": "巡检 Claude / Codex / Grok 新增或增长的会话，增量导入到 DSH。",
+        "sync.outbound.hint": "把 DSH 新增完整轮次写回对应 agent（导入源追加；原生会话落副本）。",
+        "sync.interval": "间隔（秒）",
+        "sync.run": "立即同步",
+        "sync.running": "同步中…",
+        "sync.save": "保存",
+        "sync.enabled": "开启",
+        "sync.disabled": "关闭",
+        "sync.last": "上次：{when}",
+        "sync.never": "尚未运行",
+        "sync.timer.on": "定时器开",
+        "sync.timer.off": "定时器关",
+        "sync.result": "入站 扫 {scanned} / 新 {imported} / 续 {appended} / 跳 {skipped} / 败 {failed}；出站 写回 {synced} / 跳 {outSkipped} / 败 {outFailed}",
       },
       en: {
         "trigger.title": "Import sessions from other tools (discover + single/multi select)",
@@ -117,6 +135,24 @@ window.__ModuleLoader__.load({
         "result.separator": ", ",
         "result.done": "Import done: {bits}",
         "result.nochange": "no change",
+        "tab.import": "Import",
+        "tab.sync": "Sync",
+        "sync.panel.title": "Two-way sync",
+        "sync.inbound": "External → DSH",
+        "sync.outbound": "DSH → External",
+        "sync.inbound.hint": "Watch Claude / Codex / Grok for new or grown sessions and import incrementally.",
+        "sync.outbound.hint": "Write new complete DSH turns back to the matching agent (append source, or create a copy).",
+        "sync.interval": "Interval (sec)",
+        "sync.run": "Sync now",
+        "sync.running": "Syncing…",
+        "sync.save": "Save",
+        "sync.enabled": "On",
+        "sync.disabled": "Off",
+        "sync.last": "Last: {when}",
+        "sync.never": "Never ran",
+        "sync.timer.on": "Timer on",
+        "sync.timer.off": "Timer off",
+        "sync.result": "In scanned {scanned} / new {imported} / append {appended} / skip {skipped} / fail {failed}; out wrote {synced} / skip {outSkipped} / fail {outFailed}",
       },
     };
 
@@ -301,8 +337,162 @@ window.__ModuleLoader__.load({
       }
     };
 
+    function Toggle({ on, onChange, colors }) {
+      return React.createElement("button", {
+        type: "button",
+        onClick: () => onChange(!on),
+        style: {
+          width: "40px", height: "22px", borderRadius: "999px", border: "none", cursor: "pointer",
+          background: on ? colors.accent : colors.border, position: "relative", flex: "none",
+        },
+      }, React.createElement("span", {
+        style: {
+          position: "absolute", top: "2px", left: on ? "20px" : "2px", width: "18px", height: "18px",
+          borderRadius: "50%", background: "#fff", transition: "left .12s ease",
+        },
+      }));
+    }
+
+    function FormatChecks({ value, onChange, colors, style }) {
+      const set = new Set(value || []);
+      return React.createElement("div", { style: { display: "flex", gap: "10px", flexWrap: "wrap", padding: "0 16px 8px" } },
+        ["claude", "codex", "grokbuild"].map((f) => React.createElement("label", {
+          key: f, style: { display: "flex", gap: "4px", alignItems: "center", color: colors.text, fontSize: "12px" },
+        },
+          React.createElement("input", {
+            type: "checkbox", checked: set.has(f),
+            onChange: () => {
+              const next = new Set(set);
+              if (next.has(f)) next.delete(f); else next.add(f);
+              onChange([...next]);
+            },
+          }),
+          f)));
+    }
+
+    function SyncPanel() {
+      const t = useTranslate();
+      const colors = themeColors();
+      const style = makeStyles(colors);
+      const [config, setConfig] = useState(null);
+      const [status, setStatus] = useState(null);
+      const [error, setError] = useState(null);
+      const [busy, setBusy] = useState(false);
+      const [note, setNote] = useState(null);
+
+      const load = () => {
+        fetch("/api-import/sync").then((r) => readJson(r)).then((data) => {
+          if (data && data.ok) { setConfig(data.config); setStatus(data.status); setError(null); }
+          else setError((data && data.error) || t("error.load"));
+        }).catch((err) => setError(String((err && err.message) || err)));
+      };
+      useEffect(() => { load(); }, []);
+
+      const save = async (patch) => {
+        setBusy(true);
+        try {
+          const resp = await fetch("/api-import/sync", {
+            method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(patch),
+          });
+          const data = await readJson(resp);
+          if (data && data.ok) { setConfig(data.config); setStatus(data.status); setNote(null); }
+          else setError((data && data.error) || t("error.route"));
+        } catch (err) {
+          setError(String((err && err.message) || err));
+        } finally { setBusy(false); }
+      };
+
+      const runNow = async () => {
+        setBusy(true);
+        setNote(null);
+        try {
+          const resp = await fetch("/api-import/sync", {
+            method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ runNow: true }),
+          });
+          const data = await readJson(resp);
+          if (data && data.ok) {
+            setConfig(data.config);
+            setStatus(data.status);
+            const inn = (data.result && data.result.inbound) || {};
+            const out = (data.result && data.result.outbound) || {};
+            setNote(t("sync.result", {
+              scanned: inn.scanned || 0, imported: inn.imported || 0, appended: inn.appended || 0,
+              skipped: inn.skipped || 0, failed: inn.failed || 0,
+              synced: out.synced || 0, outSkipped: out.skipped || 0, outFailed: out.failed || 0,
+            }));
+          } else setError((data && data.error) || t("error.route"));
+        } catch (err) {
+          setError(String((err && err.message) || err));
+        } finally { setBusy(false); }
+      };
+
+      if (!config) {
+        return React.createElement("div", { style: style.status }, error || t("loading"));
+      }
+      const last = config.lastRun && config.lastRun.at ? fmtTime(config.lastRun.at) : "";
+      return React.createElement("div", { style: { display: "flex", flexDirection: "column", minHeight: 0, flex: 1 } },
+        React.createElement("div", { style: style.row },
+          React.createElement("span", { style: style.label }, t("sync.inbound")),
+          React.createElement("span", { style: { flex: 1, color: colors.dimmer, fontSize: "12px" } }, t("sync.inbound.hint")),
+          React.createElement(Toggle, { on: !!config.inbound.enabled, colors, onChange: (on) => save({ inbound: { ...config.inbound, enabled: on } }) })),
+        React.createElement(FormatChecks, { value: config.inbound.formats, colors, style, onChange: (formats) => save({ inbound: { ...config.inbound, formats } }) }),
+        React.createElement("div", { style: style.row },
+          React.createElement("span", { style: style.label }, t("sync.outbound")),
+          React.createElement("span", { style: { flex: 1, color: colors.dimmer, fontSize: "12px" } }, t("sync.outbound.hint")),
+          React.createElement(Toggle, { on: !!config.outbound.enabled, colors, onChange: (on) => save({ outbound: { ...config.outbound, enabled: on } }) })),
+        React.createElement(FormatChecks, { value: config.outbound.targets, colors, style, onChange: (targets) => save({ outbound: { ...config.outbound, targets } }) }),
+        React.createElement("div", { style: style.row },
+          React.createElement("span", { style: style.label }, t("sync.interval")),
+          React.createElement("input", {
+            type: "number", min: 15, max: 3600, value: Math.round((config.intervalMs || 60000) / 1000),
+            style: { ...style.searchInput, maxWidth: "90px" },
+            onChange: (e) => setConfig({ ...config, intervalMs: Math.max(15, Number(e.target.value) || 60) * 1000 }),
+            onBlur: () => save({ intervalMs: config.intervalMs }),
+          }),
+          React.createElement("span", { style: { marginLeft: "auto", color: colors.dimmer, fontSize: "12px" } },
+            status && status.timerActive ? t("sync.timer.on") : t("sync.timer.off"))),
+        React.createElement("div", { style: style.importBar },
+          React.createElement("button", {
+            style: { ...style.primaryBtn, opacity: busy ? 0.55 : 1 }, disabled: busy, onClick: runNow,
+          }, busy ? t("sync.running") : t("sync.run"))),
+        React.createElement("div", { style: style.result }, last ? t("sync.last", { when: last }) : t("sync.never")),
+        note && React.createElement("div", { style: style.result }, note),
+        error && React.createElement("div", { style: style.error }, error));
+    }
+
+    function ShellPanel({ onClose }) {
+      const t = useTranslate();
+      const colors = themeColors();
+      const style = makeStyles(colors);
+      const [tab, setTab] = useState("import");
+      useEffect(() => {
+        const onKey = (e) => { if (e.key === "Escape") onClose(); };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+      }, [onClose]);
+      return React.createElement("div", { style: style.overlay, onClick: onClose },
+        React.createElement("div", { style: style.panel, onClick: (e) => e.stopPropagation() },
+          React.createElement("div", { style: style.header },
+            React.createElement("span", { style: style.title }, tab === "sync" ? t("sync.panel.title") : t("panel.title")),
+            React.createElement("button", { style: style.close, onClick: onClose, title: t("close") }, "✕")),
+          React.createElement("div", { style: { display: "flex", borderBottom: "1px solid " + colors.border } },
+            ["import", "sync"].map((id) => React.createElement("button", {
+              key: id,
+              onClick: () => setTab(id),
+              style: {
+                flex: 1, background: "transparent", border: "none", cursor: "pointer",
+                padding: "8px 0", color: tab === id ? colors.accent : colors.dim,
+                borderBottom: tab === id ? "2px solid " + colors.accent : "2px solid transparent",
+                fontWeight: tab === id ? 600 : 400,
+              },
+            }, t(id === "import" ? "tab.import" : "tab.sync")))),
+          tab === "import"
+            ? React.createElement(DiscoveryPanel, { onClose, embedded: true })
+            : React.createElement(SyncPanel, null)));
+    }
+
     /** 发现 + 导入面板：来源过滤 + 按工作区文件夹分组 + 单选/多选导入 */
-    function DiscoveryPanel({ onClose }) {
+    function DiscoveryPanel({ onClose, embedded }) {
       const t = useTranslate();
       const colors = themeColors();
       const style = makeStyles(colors);
@@ -351,10 +541,11 @@ window.__ModuleLoader__.load({
 
       // Esc 关闭面板（全屏 overlay 打开时会挡住页面其它操作，必须可键盘退出）
       useEffect(() => {
+        if (embedded) return undefined;
         const onKey = (e) => { if (e.key === "Escape") onClose(); };
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
-      }, [onClose]);
+      }, [onClose, embedded]);
 
       // 执行导入（单选/多选共用）：POST /api-import/import → 摘要 → 重取列表刷新状态
       const doImport = async (items) => {
@@ -491,11 +682,7 @@ window.__ModuleLoader__.load({
           rows);
       };
 
-      return React.createElement("div", { style: style.overlay, onClick: onClose },
-        React.createElement("div", { style: style.panel, onClick: (e) => e.stopPropagation() },
-          React.createElement("div", { style: style.header },
-            React.createElement("span", { style: style.title }, t("panel.title")),
-            React.createElement("button", { style: style.close, onClick: onClose, title: t("close") }, "✕")),
+      const body = React.createElement(React.Fragment, null,
           React.createElement("div", { style: style.row },
             React.createElement("span", { style: style.label }, t("source")),
             React.createElement("select", {
@@ -531,7 +718,16 @@ window.__ModuleLoader__.load({
           totalPages > 1 && React.createElement("div", { style: style.pageBar },
             React.createElement("button", { style: style.pageBtn, disabled: page === 0 || importing, onClick: () => setPage((p) => Math.max(0, p - 1)) }, t("previous")),
             React.createElement("span", { style: style.pageInfo }, t("pagination", { page: page + 1, pages: totalPages, total })),
-            React.createElement("button", { style: style.pageBtn, disabled: page >= totalPages - 1 || importing, onClick: () => setPage((p) => Math.min(totalPages - 1, p + 1)) }, t("next")))));
+            React.createElement("button", { style: style.pageBtn, disabled: page >= totalPages - 1 || importing, onClick: () => setPage((p) => Math.min(totalPages - 1, p + 1)) }, t("next"))));
+      if (embedded) {
+        return React.createElement("div", { style: { display: "flex", flexDirection: "column", minHeight: 0, flex: 1 } }, body);
+      }
+      return React.createElement("div", { style: style.overlay, onClick: onClose },
+        React.createElement("div", { style: style.panel, onClick: (e) => e.stopPropagation() },
+          React.createElement("div", { style: style.header },
+            React.createElement("span", { style: style.title }, t("panel.title")),
+            React.createElement("button", { style: style.close, onClick: onClose, title: t("close") }, "✕")),
+          body));
     }
 
     /** 插件 logo（assets/import.svg 内联，跟随 currentColor 适配明暗主题） */
@@ -613,7 +809,7 @@ window.__ModuleLoader__.load({
         },
           React.createElement(LogoIcon, { size: 16 }),
           !rail && t("trigger.label")),
-        open && React.createElement(DiscoveryPanel, { onClose: () => setOpen(false) }));
+        open && React.createElement(ShellPanel, { onClose: () => setOpen(false) }));
     }
 
     const name = "import-claude";

--- a/lib/export/codex.mjs
+++ b/lib/export/codex.mjs
@@ -1,0 +1,169 @@
+// lib/export/codex.mjs — DSH 会话事件 → Codex rollout JSONL（纯函数）
+//
+// 写出最小可被 convertCodexJsonl 再导入的子集：session_meta + response_item
+//（user / assistant / function_call / function_call_output）。不做完整 Codex
+// event_msg 镜像——目标是「Grok/Claude/DSH 续聊后，Codex 能看见同一段对话」。
+
+import { randomUUID } from 'node:crypto'
+import { tailClaudeEvents } from './claude.mjs'
+
+function eventIso(ev, meta, fallbackMs) {
+  const ms = typeof ev.time === 'number' ? ev.time
+    : meta && typeof meta.createdAt === 'number' ? meta.createdAt
+      : fallbackMs !== undefined ? fallbackMs : Date.now()
+  return new Date(ms).toISOString()
+}
+
+function textOf(blocks) {
+  if (typeof blocks === 'string') return blocks
+  if (!Array.isArray(blocks)) return ''
+  return blocks
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('\n')
+}
+
+function hasSurfaceEvents(events) {
+  return (Array.isArray(events) ? events : []).some((ev) => ev && (
+    (ev.type === 'user/message' && ev.data && ev.data.source && ev.data.source.kind === 'user')
+    || ev.type === 'assistant/message'
+    || ev.type === 'tool/result'
+  ))
+}
+
+function envelope(type, payload, timestamp) {
+  return { timestamp, type, payload }
+}
+
+export function serializeCodexRecords(events, { meta, sessionUuid, cwd, emitHeader = true }) {
+  const list = Array.isArray(events) ? events : []
+  const sessionId = String(sessionUuid)
+  const records = []
+  let skippedInjections = 0
+  let toolCalls = 0
+  let toolResults = 0
+  let droppedToolResults = 0
+  const pendingCalls = new Set()
+
+  if (emitHeader) {
+    records.push(envelope('session_meta', {
+      id: sessionId,
+      session_id: sessionId,
+      timestamp: eventIso({ time: meta && meta.createdAt }, meta),
+      cwd: cwd || (meta && meta.cwd) || '',
+      originator: 'dsh-chat-import',
+      source: 'dsh',
+    }, eventIso({ time: meta && meta.createdAt }, meta)))
+  }
+
+  for (const ev of list) {
+    if (!ev) continue
+    const ts = eventIso(ev, meta)
+    const data = ev.data || {}
+    if (ev.type === 'user/message') {
+      if (!data.source || data.source.kind !== 'user') { skippedInjections++; continue }
+      const text = textOf(data.content)
+      if (!text) continue
+      records.push(envelope('response_item', {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text }],
+      }, ts))
+    } else if (ev.type === 'assistant/message') {
+      const msg = data.message || {}
+      const text = textOf(msg.content)
+      if (text) {
+        records.push(envelope('response_item', {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text }],
+        }, ts))
+      }
+    } else if (ev.type === 'tool/call') {
+      const callId = data.callId || randomUUID()
+      records.push(envelope('response_item', {
+        type: 'function_call',
+        call_id: callId,
+        name: data.name || 'unknown',
+        arguments: typeof data.arguments === 'string' ? data.arguments : JSON.stringify(data.arguments ?? {}),
+      }, ts))
+      pendingCalls.add(callId)
+      toolCalls++
+    } else if (ev.type === 'tool/result') {
+      const msg = data.message || {}
+      const block = Array.isArray(msg.content) ? msg.content.find((b) => b && b.type === 'tool-result') : null
+      const callId = (block && block.toolCallId) || (msg.source && msg.source.callId)
+      if (!callId) { droppedToolResults++; continue }
+      records.push(envelope('response_item', {
+        type: 'function_call_output',
+        call_id: callId,
+        output: textOf(block && block.content),
+      }, ts))
+      pendingCalls.delete(callId)
+      toolResults++
+    }
+  }
+
+  for (const callId of pendingCalls) {
+    records.push(envelope('response_item', {
+      type: 'function_call_output',
+      call_id: callId,
+      output: '',
+    }, eventIso({}, meta)))
+    toolResults++
+  }
+
+  return { records, toolCalls, toolResults, droppedToolResults, skippedInjections }
+}
+
+export function serializeCodexJsonl({ meta, events, sessionUuid, cwd }, _opts = {}) {
+  if (!hasSurfaceEvents(events)) throw new Error('无可导出内容')
+  const out = serializeCodexRecords(events, { meta, sessionUuid, cwd, emitHeader: true })
+  return {
+    jsonl: out.records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    recordCount: out.records.length,
+    toolCalls: out.toolCalls,
+    toolResults: out.toolResults,
+    droppedToolResults: out.droppedToolResults,
+    skippedInjections: out.skippedInjections,
+  }
+}
+
+export function serializeCodexJsonlTail({ meta, events, sessionUuid, cwd }, _opts = {}) {
+  if (!hasSurfaceEvents(events)) throw new Error('无可导出内容')
+  const out = serializeCodexRecords(events, { meta, sessionUuid, cwd, emitHeader: false })
+  return {
+    jsonl: out.records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    recordCount: out.records.length,
+    toolCalls: out.toolCalls,
+    toolResults: out.toolResults,
+    droppedToolResults: out.droppedToolResults,
+    skippedInjections: out.skippedInjections,
+  }
+}
+
+export function verifyCodexJsonl(jsonl) {
+  const errors = []
+  const text = String(jsonl)
+  if (!text.endsWith('\n')) errors.push({ line: 1, error: '文件必须以恰好一个换行结尾' })
+  const lines = text.split('\n')
+  let count = 0
+  let sawMeta = false
+  for (let i = 0; i < lines.length; i++) {
+    if (i === lines.length - 1 && text.endsWith('\n')) continue
+    const t = lines[i].trim()
+    if (!t) { errors.push({ line: i + 1, error: '空行' }); continue }
+    let rec
+    try { rec = JSON.parse(t) } catch (err) {
+      errors.push({ line: i + 1, error: 'JSON 解析失败: ' + err.message })
+      continue
+    }
+    count++
+    if (rec && rec.type === 'session_meta') sawMeta = true
+  }
+  if (count === 0) errors.push({ line: 1, error: '无任何记录' })
+  else if (!sawMeta) errors.push({ line: 1, error: '缺少 session_meta' })
+  return errors.length ? { ok: false, errors } : { ok: true, recordCount: count }
+}
+
+export { tailClaudeEvents as tailCodexEvents }

--- a/lib/export/grokbuild.mjs
+++ b/lib/export/grokbuild.mjs
@@ -1,0 +1,148 @@
+// lib/export/grokbuild.mjs — DSH 会话事件 → Grok Build chat_history.jsonl（纯函数）
+//
+// 写出 convertGrokbuildJson 能再读回的最小子集：user / assistant / tool 行。
+// summary.json 由写回层单独维护（info.id / info.cwd / generated_title）。
+
+import { tailClaudeEvents } from './claude.mjs'
+
+function eventIso(ev, meta) {
+  const ms = typeof ev.time === 'number' ? ev.time
+    : meta && typeof meta.createdAt === 'number' ? meta.createdAt
+      : Date.now()
+  return new Date(ms).toISOString()
+}
+
+function textOf(blocks) {
+  if (typeof blocks === 'string') return blocks
+  if (!Array.isArray(blocks)) return ''
+  return blocks
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('\n')
+}
+
+function hasSurfaceEvents(events) {
+  return (Array.isArray(events) ? events : []).some((ev) => ev && (
+    (ev.type === 'user/message' && ev.data && ev.data.source && ev.data.source.kind === 'user')
+    || ev.type === 'assistant/message'
+    || ev.type === 'tool/result'
+  ))
+}
+
+export function serializeGrokbuildRecords(events, { meta } = {}) {
+  const list = Array.isArray(events) ? events : []
+  const records = []
+  let skippedInjections = 0
+  let toolCalls = 0
+  let toolResults = 0
+  let droppedToolResults = 0
+  const pending = []
+
+  for (const ev of list) {
+    if (!ev) continue
+    const ts = eventIso(ev, meta)
+    const data = ev.data || {}
+    if (ev.type === 'user/message') {
+      if (!data.source || data.source.kind !== 'user') { skippedInjections++; continue }
+      const text = textOf(data.content)
+      if (!text) continue
+      records.push({ type: 'user', content: [{ type: 'text', text }], timestamp: ts })
+    } else if (ev.type === 'assistant/message') {
+      const msg = data.message || {}
+      const content = []
+      const blocks = Array.isArray(msg.content) ? msg.content : []
+      for (const b of blocks) {
+        if (!b) continue
+        if (b.type === 'text' && typeof b.text === 'string') content.push({ type: 'text', text: b.text })
+        else if (b.type === 'reasoning' && typeof b.text === 'string') content.push({ type: 'thinking', thinking: b.text })
+        else if (b.type === 'tool-call') {
+          content.push({
+            type: 'tool_use',
+            id: b.id,
+            name: b.name,
+            input: (() => { try { return JSON.parse(b.arguments || '{}') } catch { return {} } })(),
+          })
+          pending.push(b.id)
+          toolCalls++
+        }
+      }
+      if (content.length > 0) records.push({ type: 'assistant', content, timestamp: ts })
+    } else if (ev.type === 'tool/result') {
+      const msg = data.message || {}
+      const block = Array.isArray(msg.content) ? msg.content.find((b) => b && b.type === 'tool-result') : null
+      const callId = (block && block.toolCallId) || (msg.source && msg.source.callId)
+      if (!callId) { droppedToolResults++; continue }
+      records.push({
+        type: 'tool',
+        tool_use_id: callId,
+        content: textOf(block && block.content),
+        timestamp: ts,
+        ...(block && block.isError ? { is_error: true } : {}),
+      })
+      const i = pending.indexOf(callId)
+      if (i !== -1) pending.splice(i, 1)
+      toolResults++
+    }
+  }
+
+  for (const callId of pending) {
+    records.push({ type: 'tool', tool_use_id: callId, content: '', timestamp: eventIso({}, meta) })
+    toolResults++
+  }
+
+  return { records, toolCalls, toolResults, droppedToolResults, skippedInjections }
+}
+
+export function serializeGrokbuildJsonl({ meta, events }) {
+  if (!hasSurfaceEvents(events)) throw new Error('无可导出内容')
+  const out = serializeGrokbuildRecords(events, { meta })
+  return {
+    jsonl: out.records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    recordCount: out.records.length,
+    toolCalls: out.toolCalls,
+    toolResults: out.toolResults,
+    droppedToolResults: out.droppedToolResults,
+    skippedInjections: out.skippedInjections,
+  }
+}
+
+export function serializeGrokbuildJsonlTail({ meta, events }) {
+  return serializeGrokbuildJsonl({ meta, events })
+}
+
+export function buildGrokSummary({ sessionUuid, cwd, title, createdAt, updatedAt, numMessages }) {
+  const now = new Date(updatedAt || Date.now()).toISOString()
+  return {
+    info: { id: sessionUuid, cwd: cwd || '' },
+    session_summary: title || '',
+    generated_title: title || '',
+    created_at: new Date(createdAt || Date.now()).toISOString(),
+    updated_at: now,
+    last_active_at: now,
+    num_messages: numMessages || 0,
+    num_chat_messages: numMessages || 0,
+    chat_format_version: 1,
+    originator: 'dsh-chat-import',
+  }
+}
+
+export function verifyGrokbuildJsonl(jsonl) {
+  const errors = []
+  const text = String(jsonl)
+  if (text && !text.endsWith('\n')) errors.push({ line: 1, error: '文件必须以恰好一个换行结尾' })
+  const lines = text.split('\n')
+  let count = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (i === lines.length - 1 && text.endsWith('\n')) continue
+    const t = lines[i].trim()
+    if (!t) { errors.push({ line: i + 1, error: '空行' }); continue }
+    try { JSON.parse(t) } catch (err) {
+      errors.push({ line: i + 1, error: 'JSON 解析失败: ' + err.message })
+      continue
+    }
+    count++
+  }
+  return errors.length ? { ok: false, errors } : { ok: true, recordCount: count }
+}
+
+export { tailClaudeEvents as tailGrokbuildEvents }

--- a/lib/sync-config.mjs
+++ b/lib/sync-config.mjs
@@ -1,0 +1,138 @@
+// lib/sync-config.mjs — 双向增量同步配置 + 出站映射
+//
+// 落盘在 `$DSH_HOME/dsh-chat-import/sync.json`（开关 / 间隔 / 上次巡检）与
+// `outbound.json`（原生 DSH 会话 → 外部副本路径）。默认全部关闭：必须由控制面板
+// 显式打开才会巡检或写出，避免静默改写 Claude / Codex / Grok 文件。
+
+import { join } from 'node:path'
+import { mkdir, open, readFile, rename, rm } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { resolveRegistryDir } from './imports.mjs'
+
+export const SYNC_CONFIG_VERSION = 1
+export const DEFAULT_INTERVAL_MS = 60_000
+export const SYNC_FORMATS = ['claude', 'codex', 'grokbuild']
+
+const emptyConfig = () => ({
+  version: SYNC_CONFIG_VERSION,
+  inbound: { enabled: false, formats: [...SYNC_FORMATS] },
+  outbound: { enabled: false, targets: [...SYNC_FORMATS], roots: {} },
+  intervalMs: DEFAULT_INTERVAL_MS,
+  lastRun: null,
+})
+
+let writeChain = Promise.resolve()
+
+async function writeAtomic(filePath, data) {
+  const slash = filePath.lastIndexOf('/')
+  const back = filePath.lastIndexOf('\\')
+  const cut = Math.max(slash, back)
+  const dir = cut >= 0 ? filePath.slice(0, cut) : '.'
+  const tmpPath = join(dir, '.' + randomUUID() + '.tmp')
+  try {
+    const handle = await open(tmpPath, 'wx')
+    try {
+      await handle.writeFile(data, 'utf8')
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await rename(tmpPath, filePath)
+  } catch (err) {
+    await rm(tmpPath, { force: true })
+    throw err
+  }
+}
+
+function clampFormats(list, fallback) {
+  const allowed = new Set(SYNC_FORMATS)
+  const out = (Array.isArray(list) ? list : []).filter((f) => allowed.has(f))
+  return out.length > 0 ? [...new Set(out)] : [...fallback]
+}
+
+function normalizeConfig(raw) {
+  const base = emptyConfig()
+  if (!raw || typeof raw !== 'object') return base
+  const inbound = raw.inbound && typeof raw.inbound === 'object' ? raw.inbound : {}
+  const outbound = raw.outbound && typeof raw.outbound === 'object' ? raw.outbound : {}
+  const interval = Number(raw.intervalMs)
+  return {
+    version: SYNC_CONFIG_VERSION,
+    inbound: {
+      enabled: inbound.enabled === true,
+      formats: clampFormats(inbound.formats, base.inbound.formats),
+    },
+    outbound: {
+      enabled: outbound.enabled === true,
+      targets: clampFormats(outbound.targets, base.outbound.targets),
+      roots: outbound.roots && typeof outbound.roots === 'object' ? {
+        claude: typeof outbound.roots.claude === 'string' ? outbound.roots.claude : undefined,
+        codex: typeof outbound.roots.codex === 'string' ? outbound.roots.codex : undefined,
+        grokbuild: typeof outbound.roots.grokbuild === 'string' ? outbound.roots.grokbuild : undefined,
+      } : {},
+    },
+    intervalMs: Number.isFinite(interval) ? Math.min(Math.max(Math.trunc(interval), 15_000), 3_600_000) : DEFAULT_INTERVAL_MS,
+    lastRun: raw.lastRun && typeof raw.lastRun === 'object' ? raw.lastRun : null,
+  }
+}
+
+async function readJson(filePath, fallback) {
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'))
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.warn('[dsh-chat-import] 同步配置损坏，按默认处理：' + String((err && err.message) || err))
+    }
+  }
+  return fallback
+}
+
+export async function loadSyncConfig(registryDir = resolveRegistryDir()) {
+  await writeChain.catch(() => {})
+  return normalizeConfig(await readJson(join(registryDir, 'sync.json'), emptyConfig()))
+}
+
+export function saveSyncConfig(registryDir, next) {
+  const data = normalizeConfig(next)
+  const run = writeChain.then(async () => {
+    await mkdir(registryDir, { recursive: true })
+    await writeAtomic(join(registryDir, 'sync.json'), JSON.stringify(data, null, 2) + '\n')
+    return data
+  })
+  writeChain = run.catch(() => {})
+  return run
+}
+
+export async function patchSyncConfig(registryDir, patch) {
+  const cur = await loadSyncConfig(registryDir)
+  const merged = {
+    ...cur,
+    ...(patch && typeof patch === 'object' ? patch : {}),
+    inbound: { ...cur.inbound, ...(patch && patch.inbound ? patch.inbound : {}) },
+    outbound: { ...cur.outbound, ...(patch && patch.outbound ? patch.outbound : {}) },
+  }
+  return saveSyncConfig(registryDir, merged)
+}
+
+export async function loadOutboundMap(registryDir = resolveRegistryDir()) {
+  await writeChain.catch(() => {})
+  const parsed = await readJson(join(registryDir, 'outbound.json'), { version: 1, mappings: {} })
+  const mappings = parsed.mappings && typeof parsed.mappings === 'object' ? parsed.mappings : {}
+  return { version: 1, mappings }
+}
+
+export function rememberOutbound(registryDir, sessionId, mapping) {
+  if (typeof sessionId !== 'string' || !sessionId) return Promise.resolve()
+  const run = writeChain.then(async () => {
+    const file = join(registryDir, 'outbound.json')
+    const parsed = await readJson(file, { version: 1, mappings: {} })
+    if (!parsed.mappings || typeof parsed.mappings !== 'object') parsed.mappings = {}
+    parsed.version = 1
+    parsed.mappings[sessionId] = { ...(parsed.mappings[sessionId] || {}), ...mapping }
+    await mkdir(registryDir, { recursive: true })
+    await writeAtomic(file, JSON.stringify(parsed, null, 2) + '\n')
+  })
+  writeChain = run.catch(() => {})
+  return run
+}

--- a/lib/sync-loop.mjs
+++ b/lib/sync-loop.mjs
@@ -1,0 +1,506 @@
+// lib/sync-loop.mjs — 双向增量同步编排（控制面板 + 定时巡检）
+//
+// 入站：对开启的来源跑 discover → importDiscoveryItem（复用幂等 / 续写状态机）。
+// 出站：把 DSH 会话增量写回 Claude / Codex / Grok。导入源走源文件；原生会话
+// 在对应 agent 默认根下落一份副本（outbound.json 记映射）。
+// 默认关闭；apply 时不启定时器，避免测试进程挂起。只有面板打开开关才巡检。
+
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { mkdir } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { discoverSessions } from './discovery.mjs'
+import { makeDiscoveryHost } from './discovery-host.mjs'
+import { loadImports, rememberImport, unwrapRecord, archivedSessionIds } from './imports.mjs'
+import { resolveImportBudget } from './budget.mjs'
+import { importTranscript } from './import-core.mjs'
+import { importGrokbuildSession } from './import-variants.mjs'
+import { syncClaudeSession } from './backfill.mjs'
+import { serializeClaudeJsonl, serializeClaudeJsonlTail, tailClaudeEvents, verifyClaudeJsonl, slugifyClaudeCwd } from '../export.mjs'
+import { serializeCodexJsonl, serializeCodexJsonlTail, verifyCodexJsonl } from './export/codex.mjs'
+import { serializeGrokbuildJsonl, serializeGrokbuildJsonlTail, verifyGrokbuildJsonl, buildGrokSummary } from './export/grokbuild.mjs'
+import { convertClaudeJsonl, convertCodexJsonl, convertGrokbuildJson } from '../convert.mjs'
+import {
+  loadSyncConfig, saveSyncConfig, loadOutboundMap, rememberOutbound, SYNC_FORMATS,
+} from './sync-config.mjs'
+
+const FORMAT_SOURCE = {
+  claude: 'claude-code',
+  codex: 'codex',
+  grokbuild: 'grokbuild',
+}
+
+const TOOL_FORMAT = {
+  'claude-code': 'claude',
+  claude: 'claude',
+  codex: 'codex',
+  grokbuild: 'grokbuild',
+}
+
+const lastStatus = {
+  running: false,
+  lastRunAt: null,
+  lastError: null,
+  inbound: null,
+  outbound: null,
+}
+
+let timer = null
+let timerCtx = null
+let timerRegistryDir = null
+
+function homeDir() {
+  return process.env.HOME || homedir()
+}
+
+function pad(n) {
+  return String(n).padStart(2, '0')
+}
+
+function localStamp(ms) {
+  const d = new Date(ms || Date.now())
+  return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
+    + 'T' + pad(d.getHours()) + '-' + pad(d.getMinutes()) + '-' + pad(d.getSeconds())
+}
+
+export function encodeGrokCwd(cwd) {
+  return encodeURIComponent(String(cwd || ''))
+}
+
+export function defaultCodexPath(sessionUuid, createdAt, home = homeDir(), root) {
+  const d = new Date(createdAt || Date.now())
+  const y = d.getFullYear()
+  const m = pad(d.getMonth() + 1)
+  const day = pad(d.getDate())
+  const base = root || join(home, '.codex', 'sessions')
+  return join(base, String(y), m, day, 'rollout-' + localStamp(d.getTime()) + '-' + sessionUuid + '.jsonl')
+}
+
+export function defaultClaudePath(sessionUuid, cwd, home = homeDir(), root) {
+  const base = root || join(home, '.claude', 'projects')
+  return join(base, slugifyClaudeCwd(cwd || home), sessionUuid + '.jsonl')
+}
+
+export function defaultGrokDir(sessionUuid, cwd, home = homeDir(), root) {
+  const base = root || join(home, '.grok', 'sessions')
+  return join(base, encodeGrokCwd(cwd || home), sessionUuid)
+}
+
+function sessionTitle(events, fallback) {
+  for (const ev of events || []) {
+    if (ev && ev.type === 'session/title' && ev.data && typeof ev.data.title === 'string' && ev.data.title.trim()) {
+      return ev.data.title.trim()
+    }
+  }
+  return fallback || ''
+}
+
+function importedMarker(events) {
+  const first = Array.isArray(events) && events[0]
+  if (!first || first.type !== 'session/imported' || !first.data) return null
+  return first.data
+}
+
+function outboundPaths(map) {
+  const set = new Set()
+  const mappings = map && map.mappings && typeof map.mappings === 'object' ? map.mappings : {}
+  for (const entry of Object.values(mappings)) {
+    if (!entry || typeof entry !== 'object') continue
+    for (const slot of Object.values(entry)) {
+      if (!slot || typeof slot !== 'object') continue
+      if (typeof slot.filePath === 'string') set.add(slot.filePath)
+      if (typeof slot.dirPath === 'string') set.add(slot.dirPath)
+    }
+  }
+  return set
+}
+
+async function ensureParent(filePath) {
+  await mkdir(dirname(filePath), { recursive: true })
+}
+
+async function writeNew(ctx, filePath, content) {
+  await ensureParent(filePath)
+  const target = await ctx.fs.resolve(filePath)
+  await ctx.fs.writeText(target, content, { kind: 'createIfAbsent', displayPath: filePath })
+}
+
+async function appendFile(ctx, filePath, existing, tail, verify) {
+  const target = await ctx.fs.resolve(filePath)
+  const stat = await ctx.fs.stat(target)
+  if (!stat || stat.type !== 'file') throw new Error('写回目标不存在: ' + filePath)
+  const newContent = existing.endsWith('\n') ? existing + tail : existing + '\n' + tail
+  const check = verify(newContent)
+  if (!check.ok) return { ok: false, precheck: check }
+  const outcome = await ctx.fs.writeText(target, newContent, { kind: 'replaceIfVersion', version: stat.version })
+  return { ok: true, content: newContent, version: outcome && outcome.version, size: newContent.length }
+}
+
+function countTurns(events) {
+  let n = 0
+  for (const ev of events || []) if (ev && ev.type === 'turn/start') n++
+  return n
+}
+
+function lastTurnOf(events) {
+  for (let i = (events || []).length - 1; i >= 0; i--) {
+    const ev = events[i]
+    if (ev && ev.type === 'turn/end' && ev.data && typeof ev.data.turn === 'number') return ev.data.turn
+  }
+  return countTurns(events)
+}
+
+async function inboundOnce(ctx, registryDir, config, { home, path } = {}) {
+  const formats = config.inbound.enabled ? config.inbound.formats : []
+  const summary = { scanned: 0, imported: 0, appended: 0, skipped: 0, failed: 0, errors: [] }
+  if (formats.length === 0) return summary
+  const registry = await loadImports(registryDir)
+  const outbound = await loadOutboundMap(registryDir)
+  const skipPaths = outboundPaths(outbound)
+  const budgetInfo = await resolveImportBudget(ctx, {})
+  const host = makeDiscoveryHost(ctx)
+  const archivedIds = archivedSessionIds(ctx)
+  const sessions = []
+  for (const format of formats) {
+    const found = await discoverSessions({
+      format,
+      host,
+      home,
+      path: formats.length === 1 ? path : undefined,
+      imports: registry.imports,
+      cacheDir: registryDir,
+      archivedIds,
+    })
+    for (const s of found.sessions || []) {
+      if (!skipPaths.has(s.sourcePath)) sessions.push(s)
+    }
+  }
+  summary.scanned = sessions.length
+  for (const s of sessions) {
+    try {
+      const args = { path: s.sourcePath, force: false, budget: budgetInfo.budget, budgetSource: budgetInfo.source }
+      const target = await ctx.fs.resolve(s.sourcePath)
+      const out = s.format === 'grokbuild'
+        ? await importGrokbuildSession(ctx, target, args, { registryDir })
+        : await importTranscript(ctx, target, args, s.format === 'codex' ? convertCodexJsonl : convertClaudeJsonl, { registryDir })
+      if (out.mode === 'batch') {
+        summary.imported += out.imported || 0
+        summary.appended += out.appended || 0
+        summary.skipped += (out.alreadyImported || 0) + (out.skipped || 0)
+        summary.failed += out.failed || 0
+      } else if (out.status === 'imported') summary.imported++
+      else if (out.status === 'appended') summary.appended++
+      else if (out.status === 'failed') summary.failed++
+      else summary.skipped++
+    } catch (err) {
+      summary.failed++
+      if (summary.errors.length < 8) {
+        summary.errors.push({ sourcePath: s.sourcePath, error: String((err && err.message) || err) })
+      }
+    }
+  }
+  return summary
+}
+
+async function serializeFull(format, payload) {
+  if (format === 'claude') return serializeClaudeJsonl(payload)
+  if (format === 'codex') return serializeCodexJsonl(payload)
+  return serializeGrokbuildJsonl(payload)
+}
+
+async function serializeTail(format, payload) {
+  if (format === 'claude') return serializeClaudeJsonlTail(payload)
+  if (format === 'codex') return serializeCodexJsonlTail(payload)
+  return serializeGrokbuildJsonlTail(payload)
+}
+
+function verifyOf(format) {
+  if (format === 'claude') return verifyClaudeJsonl
+  if (format === 'codex') return verifyCodexJsonl
+  return verifyGrokbuildJsonl
+}
+
+async function convertExisting(format, ctx, mapping) {
+  if (format === 'grokbuild') {
+    const dir = mapping.dirPath
+    const chatTarget = await ctx.fs.resolve(join(dir, 'chat_history.jsonl'))
+    const chatStat = await ctx.fs.stat(chatTarget)
+    if (!chatStat || chatStat.type !== 'file') return { missing: true }
+    const summaryTarget = await ctx.fs.resolve(join(dir, 'summary.json'))
+    let summaryText = '{}'
+    try { summaryText = await ctx.fs.readText(summaryTarget) } catch { /* 仅有历史、无 summary */ }
+    const chatText = await ctx.fs.readText(chatTarget)
+    return { converted: convertGrokbuildJson(summaryText, chatText, {}), chatText, summaryText, dir, stat: chatStat }
+  }
+  const target = await ctx.fs.resolve(mapping.filePath)
+  const stat = await ctx.fs.stat(target)
+  if (!stat || stat.type !== 'file') return { missing: true }
+  const text = await ctx.fs.readText(target)
+  const converted = format === 'claude' ? convertClaudeJsonl(text, {}) : convertCodexJsonl(text, {})
+  return { converted, text, stat }
+}
+
+async function seedMapping(ctx, format, header, meta, events, sourcePath, roots = {}) {
+  const sessionUuid = randomUUID()
+  const cwd = header.cwd || meta.cwd || homeDir()
+  if (format === 'claude') {
+    return { filePath: sourcePath || defaultClaudePath(sessionUuid, cwd, homeDir(), roots.claude), sessionUuid, lastWrittenSeq: 0, lastWrittenTurn: 0 }
+  }
+  if (format === 'codex') {
+    return { filePath: sourcePath || defaultCodexPath(sessionUuid, header.createdAt || meta.createdAt, homeDir(), roots.codex), sessionUuid, lastWrittenSeq: 0, lastWrittenTurn: 0 }
+  }
+  const dir = sourcePath || defaultGrokDir(sessionUuid, cwd, homeDir(), roots.grokbuild)
+  return { dirPath: dir, filePath: join(dir, 'chat_history.jsonl'), sessionUuid, lastWrittenSeq: 0, lastWrittenTurn: 0 }
+}
+
+async function writeGrokSummary(ctx, mapping, header, meta, events, dryRun) {
+  const summary = buildGrokSummary({
+    sessionUuid: mapping.sessionUuid,
+    cwd: header.cwd || meta.cwd || '',
+    title: sessionTitle(events, header.title),
+    createdAt: meta.createdAt || header.createdAt,
+    updatedAt: Date.now(),
+    numMessages: (events || []).filter((e) => e && (e.type === 'user/message' || e.type === 'assistant/message')).length,
+  })
+  const path = join(mapping.dirPath, 'summary.json')
+  if (dryRun) return
+  await ensureParent(path)
+  const target = await ctx.fs.resolve(path)
+  const stat = await ctx.fs.stat(target)
+  const text = JSON.stringify(summary, null, 2) + '\n'
+  if (!stat || stat.type !== 'file') {
+    await ctx.fs.writeText(target, text, { kind: 'createIfAbsent', displayPath: path })
+  } else {
+    try {
+      await ctx.fs.writeText(target, text, { kind: 'replaceIfVersion', version: stat.version })
+    } catch {
+      // 摘要刷新失败不阻断历史写回
+    }
+  }
+}
+
+async function outboundOne(ctx, registryDir, header, targetFormat, dryRun, roots = {}) {
+  const sp = ctx.get('sessionPersistence')
+  const { meta, events } = await sp.readFrom(header.id, 0)
+  const marker = importedMarker(events)
+  const originFormat = marker && marker.tool ? TOOL_FORMAT[marker.tool] : null
+  const map = await loadOutboundMap(registryDir)
+  const entry = (map.mappings[header.id] && typeof map.mappings[header.id] === 'object') ? map.mappings[header.id] : {}
+  let mapping = entry[targetFormat]
+  const sourcePath = marker && typeof marker.sourcePath === 'string' ? marker.sourcePath : null
+  const useSource = originFormat === targetFormat && sourcePath
+
+  if (targetFormat === 'claude' && useSource && !dryRun) {
+    try {
+      const out = await syncClaudeSession(ctx, { sessionId: header.id, target: 'source', dryRun }, { registryDir })
+      return { format: targetFormat, sessionId: header.id, ...out }
+    } catch (err) {
+      return { format: targetFormat, sessionId: header.id, status: 'failed', error: String((err && err.message) || err) }
+    }
+  }
+
+  if (!mapping) {
+    mapping = await seedMapping(ctx, targetFormat, header, meta || header, events, useSource ? sourcePath : null, roots)
+  }
+
+  const cwd = header.cwd || (meta && meta.cwd) || homeDir()
+  const payloadBase = { meta, sessionUuid: mapping.sessionUuid, cwd }
+
+  if (!mapping.lastWrittenSeq) {
+    const existingSeed = await convertExisting(targetFormat, ctx, mapping)
+    if (!existingSeed.missing) {
+      const fileEvents = existingSeed.converted && Array.isArray(existingSeed.converted.events)
+        ? existingSeed.converted.events.length
+        : 0
+      mapping = {
+        ...mapping,
+        lastWrittenSeq: fileEvents > 0 ? fileEvents : events.length,
+        lastWrittenTurn: existingSeed.converted && Array.isArray(existingSeed.converted.turns)
+          ? existingSeed.converted.turns.length
+          : lastTurnOf(events),
+        lastSize: (existingSeed.chatText !== undefined ? existingSeed.chatText : existingSeed.text || '').length,
+        writtenAt: Date.now(),
+      }
+      if (!dryRun) await rememberOutbound(registryDir, header.id, { [targetFormat]: mapping })
+    } else {
+      let full
+      try {
+        full = await serializeFull(targetFormat, { ...payloadBase, events })
+      } catch (err) {
+        return { format: targetFormat, sessionId: header.id, status: 'skipped', reason: String((err && err.message) || err) }
+      }
+      if (dryRun) {
+        return { format: targetFormat, sessionId: header.id, status: 'synced', dryRun: true, filePath: mapping.filePath, appendedRecords: full.recordCount }
+      }
+      if (targetFormat === 'grokbuild') {
+        await ensureParent(mapping.filePath)
+        await writeNew(ctx, mapping.filePath, full.jsonl)
+        await writeGrokSummary(ctx, mapping, header, meta || header, events, dryRun)
+      } else {
+        await writeNew(ctx, mapping.filePath, full.jsonl)
+      }
+      const next = {
+        ...mapping,
+        lastWrittenSeq: events.length,
+        lastWrittenTurn: lastTurnOf(events),
+        lastSize: full.jsonl.length,
+        writtenAt: Date.now(),
+      }
+      await rememberOutbound(registryDir, header.id, { [targetFormat]: next })
+      return { format: targetFormat, sessionId: header.id, status: 'synced', filePath: mapping.filePath, appendedTurns: countTurns(events), appendedRecords: full.recordCount, dryRun: false }
+    }
+  }
+
+  const existing = await convertExisting(targetFormat, ctx, mapping)
+  if (existing.missing) {
+    mapping.lastWrittenSeq = 0
+    return outboundOne(ctx, registryDir, header, targetFormat, dryRun, roots)
+  }
+  if (mapping.lastSize && existing.stat && existing.stat.size < mapping.lastSize) {
+    return { format: targetFormat, sessionId: header.id, status: 'skipped', sourceShrunk: true, filePath: mapping.filePath }
+  }
+  const tail = tailClaudeEvents(events, { fromSeq: mapping.lastWrittenSeq })
+  if (tail.events.length === 0) {
+    return { format: targetFormat, sessionId: header.id, status: 'no-new-turns', filePath: mapping.filePath, dryRun, ...(tail.droppedIncompleteTurn ? { incompleteFinalTurn: true } : {}) }
+  }
+  let piece
+  try {
+    piece = await serializeTail(targetFormat, { ...payloadBase, events: tail.events })
+  } catch (err) {
+    return { format: targetFormat, sessionId: header.id, status: 'skipped', reason: String((err && err.message) || err) }
+  }
+  if (dryRun) {
+    return { format: targetFormat, sessionId: header.id, status: 'synced', dryRun: true, filePath: mapping.filePath, appendedTurns: countTurns(tail.events), appendedRecords: piece.recordCount }
+  }
+  const body = existing.chatText !== undefined ? existing.chatText : existing.text
+  if (targetFormat === 'grokbuild') {
+    await ensureParent(mapping.filePath)
+    const target = await ctx.fs.resolve(mapping.filePath)
+    const stat = await ctx.fs.stat(target)
+    const newContent = (body || '').endsWith('\n') || !body ? (body || '') + piece.jsonl : body + '\n' + piece.jsonl
+    const check = verifyGrokbuildJsonl(newContent)
+    if (!check.ok) return { format: targetFormat, sessionId: header.id, status: 'skipped', precheckFailed: true, precheck: check }
+    if (!stat || stat.type !== 'file') await writeNew(ctx, mapping.filePath, newContent)
+    else await ctx.fs.writeText(target, newContent, { kind: 'replaceIfVersion', version: stat.version })
+    await writeGrokSummary(ctx, mapping, header, meta || header, events, dryRun)
+  } else {
+    const appended = await appendFile(ctx, mapping.filePath, body || '', piece.jsonl, verifyOf(targetFormat))
+    if (!appended.ok) return { format: targetFormat, sessionId: header.id, status: 'skipped', precheckFailed: true, precheck: appended.precheck }
+  }
+  const next = {
+    ...mapping,
+    lastWrittenSeq: events.length,
+    lastWrittenTurn: lastTurnOf(tail.events),
+    lastSize: (body || '').length + piece.jsonl.length,
+    writtenAt: Date.now(),
+  }
+  await rememberOutbound(registryDir, header.id, { [targetFormat]: next })
+  if (useSource && sourcePath) {
+    const rec = unwrapRecord((await loadImports(registryDir)).imports[sourcePath])
+    if (rec && rec.kind === 'single') {
+      await rememberImport(registryDir, sourcePath, {
+        ...rec,
+        turns: lastTurnOf(events),
+        events: events.length,
+        sizeBytes: next.lastSize,
+      })
+    }
+  }
+  return {
+    format: targetFormat,
+    sessionId: header.id,
+    status: 'synced',
+    filePath: mapping.filePath,
+    appendedTurns: countTurns(tail.events),
+    appendedRecords: piece.recordCount,
+    dryRun: false,
+  }
+}
+
+async function outboundOnce(ctx, registryDir, config, dryRun) {
+  const targets = config.outbound.enabled ? config.outbound.targets : []
+  const summary = { sessions: 0, synced: 0, skipped: 0, failed: 0, results: [] }
+  if (targets.length === 0) return summary
+  const sp = ctx.get('sessionPersistence')
+  if (!sp || typeof sp.list !== 'function' || typeof sp.readFrom !== 'function') {
+    return { ...summary, failed: 1, results: [{ status: 'failed', error: 'sessionPersistence 不可用' }] }
+  }
+  const headers = await sp.list()
+  summary.sessions = headers.length
+  for (const header of headers) {
+    for (const format of targets) {
+      try {
+        const one = await outboundOne(ctx, registryDir, header, format, dryRun, config.outbound.roots || {})
+        if (one.status === 'synced') summary.synced++
+        else if (one.status === 'failed') summary.failed++
+        else summary.skipped++
+        if (summary.results.length < 40) summary.results.push(one)
+      } catch (err) {
+        summary.failed++
+        if (summary.results.length < 40) {
+          summary.results.push({ format, sessionId: header.id, status: 'failed', error: String((err && err.message) || err) })
+        }
+      }
+    }
+  }
+  return summary
+}
+
+export async function runSyncOnce(ctx, registryDir, { dryRun = false, home, path } = {}) {
+  if (lastStatus.running) return { ok: false, error: '同步正在进行', ...lastStatus }
+  lastStatus.running = true
+  lastStatus.lastError = null
+  try {
+    const config = await loadSyncConfig(registryDir)
+    const inbound = await inboundOnce(ctx, registryDir, config, { home, path })
+    const outbound = await outboundOnce(ctx, registryDir, config, dryRun)
+    const lastRun = { at: Date.now(), inbound, outbound, dryRun }
+    await saveSyncConfig(registryDir, { ...config, lastRun })
+    lastStatus.lastRunAt = lastRun.at
+    lastStatus.inbound = inbound
+    lastStatus.outbound = outbound
+    return { ok: true, config: await loadSyncConfig(registryDir), inbound, outbound, dryRun }
+  } catch (err) {
+    lastStatus.lastError = String((err && err.message) || err)
+    return { ok: false, error: lastStatus.lastError }
+  } finally {
+    lastStatus.running = false
+  }
+}
+
+export function getSyncStatus() {
+  return { ...lastStatus, timerActive: timer !== null, formats: SYNC_FORMATS }
+}
+
+export function stopSyncTimer() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+export async function startSyncTimer(ctx, registryDir) {
+  timerCtx = ctx
+  timerRegistryDir = registryDir
+  stopSyncTimer()
+  const config = await loadSyncConfig(registryDir)
+  if (!config.inbound.enabled && !config.outbound.enabled) return config
+  timer = setInterval(() => {
+    runSyncOnce(timerCtx, timerRegistryDir).catch((err) => {
+      lastStatus.lastError = String((err && err.message) || err)
+    })
+  }, config.intervalMs)
+  if (typeof timer.unref === 'function') timer.unref()
+  return config
+}
+
+export function registerSyncLoop(ctx, registryDir) {
+  startSyncTimer(ctx, registryDir).catch((err) => {
+    console.warn('[dsh-chat-import] 同步定时器启动失败：' + String((err && err.message) || err))
+  })
+  if (typeof ctx.effect === 'function') {
+    ctx.effect(() => () => stopSyncTimer())
+  }
+}
+
+export { FORMAT_SOURCE, lastStatus }

--- a/lib/sync-panel.mjs
+++ b/lib/sync-panel.mjs
@@ -1,0 +1,61 @@
+// lib/sync-panel.mjs — 双向同步控制面板路由
+//
+// GET  /api-import/sync   读开关 / 间隔 / 上次巡检 / 定时器状态
+// POST /api-import/sync   改开关（inbound/outbound/intervalMs）或立即跑一轮（runNow）
+
+import { loadSyncConfig, patchSyncConfig, SYNC_FORMATS } from './sync-config.mjs'
+import { getSyncStatus, runSyncOnce, startSyncTimer } from './sync-loop.mjs'
+
+async function readBody(req) {
+  const chunks = []
+  for await (const chunk of req) chunks.push(String(chunk))
+  return JSON.parse(chunks.join('') || '{}')
+}
+
+function json(res, code, body) {
+  res.writeHead(code, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+export function registerSyncRoutes(ctx, ws, registryDir) {
+  const replyStatus = async () => {
+    const config = await loadSyncConfig(registryDir)
+    return { ok: true, config, status: getSyncStatus(), formats: SYNC_FORMATS }
+  }
+
+  ws.register({
+    kind: 'exact',
+    path: '/api-import/sync',
+    handler: async (req, res) => {
+      try {
+        const method = String(req.method || 'GET').toUpperCase()
+        if (method === 'GET') {
+          json(res, 200, await replyStatus())
+          return
+        }
+        if (method !== 'POST') {
+          json(res, 405, { ok: false, error: '只支持 GET / POST' })
+          return
+        }
+        const body = await readBody(req)
+        if (body.runNow === true) {
+          const out = await runSyncOnce(ctx, registryDir, {
+            dryRun: body.dryRun === true,
+            path: typeof body.path === 'string' ? body.path : undefined,
+          })
+          json(res, out.ok === false ? 500 : 200, { ...(await replyStatus()), result: out })
+          return
+        }
+        const patch = {}
+        if (body.inbound && typeof body.inbound === 'object') patch.inbound = body.inbound
+        if (body.outbound && typeof body.outbound === 'object') patch.outbound = body.outbound
+        if (body.intervalMs !== undefined) patch.intervalMs = body.intervalMs
+        await patchSyncConfig(registryDir, patch)
+        await startSyncTimer(ctx, registryDir)
+        json(res, 200, await replyStatus())
+      } catch (err) {
+        json(res, 500, { ok: false, error: String((err && err.message) || err) })
+      }
+    },
+  })
+}

--- a/package.json
+++ b/package.json
@@ -93,16 +93,13 @@
     "transcript"
   ],
   "author": "Nwflower <1679659@qq.com>",
-  "contributors": [
-    "Scarlett (https://github.com/AI-Scarlett)"
-  ],
-  "homepage": "https://github.com/AI-Scarlett/dsh-chat-import",
+  "homepage": "https://github.com/Nwflower/dsh-chat-import",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/AI-Scarlett/dsh-chat-import.git"
+    "url": "git+https://github.com/Nwflower/dsh-chat-import.git"
   },
   "bugs": {
-    "url": "https://github.com/AI-Scarlett/dsh-chat-import/issues"
+    "url": "https://github.com/Nwflower/dsh-chat-import/issues"
   },
   "engines": {
     "node": ">=22.13"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "lib/retract.mjs",
     "lib/discovery-host.mjs",
     "lib/panel.mjs",
+    "lib/sync-config.mjs",
+    "lib/sync-loop.mjs",
+    "lib/sync-panel.mjs",
     "lib/tools.mjs",
     "lib/dsh.mjs",
     "lib/convert",
@@ -90,13 +93,16 @@
     "transcript"
   ],
   "author": "Nwflower <1679659@qq.com>",
-  "homepage": "https://github.com/Nwflower/dsh-chat-import",
+  "contributors": [
+    "Scarlett (https://github.com/AI-Scarlett)"
+  ],
+  "homepage": "https://github.com/AI-Scarlett/dsh-chat-import",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Nwflower/dsh-chat-import.git"
+    "url": "git+https://github.com/AI-Scarlett/dsh-chat-import.git"
   },
   "bugs": {
-    "url": "https://github.com/Nwflower/dsh-chat-import/issues"
+    "url": "https://github.com/AI-Scarlett/dsh-chat-import/issues"
   },
   "engines": {
     "node": ">=22.13"

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -238,6 +238,7 @@ function makeCtx(tree, opts = {}) {
       register(def) { registered.push(def); return () => {} },
     },
     on() { return () => {} }, // REQ-53：apply 监听 agent/session-start（本测试不模拟事件）
+    effect() { return () => {} },
   }
   // 测试辅助：按名字取出注册的工具定义
   ctx.tools.registered = (toolName) => registered.find((d) => d.name === toolName)
@@ -3174,8 +3175,10 @@ test('REQ-41 apply 注册 webServer 路由（POST /api-import/sessions + /api-im
   apply(ctx)
   const sessions = webRoutes.find((r) => r.path === '/api-import/sessions')
   const imp = webRoutes.find((r) => r.path === '/api-import/import')
+  const sync = webRoutes.find((r) => r.path === '/api-import/sync')
   assert.ok(sessions)
   assert.ok(imp)
+  assert.ok(sync)
   assert.equal(sessions.kind, 'exact')
   assert.equal(imp.kind, 'exact')
   assert.equal(typeof sessions.handler, 'function')

--- a/test/sync.test.mjs
+++ b/test/sync.test.mjs
@@ -1,0 +1,252 @@
+// sync.test.mjs — 双向增量同步：配置、Codex/Grok 往返、入站巡检、出站写回
+import { test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { serializeCodexJsonl } from '../lib/export/codex.mjs'
+import { serializeGrokbuildJsonl, buildGrokSummary } from '../lib/export/grokbuild.mjs'
+import { convertCodexJsonl, convertGrokbuildJson } from '../convert.mjs'
+import { loadSyncConfig, saveSyncConfig, DEFAULT_INTERVAL_MS } from '../lib/sync-config.mjs'
+import { runSyncOnce, stopSyncTimer } from '../lib/sync-loop.mjs'
+import { registerSyncRoutes } from '../lib/sync-panel.mjs'
+import { clearScanCache } from '../lib/discovery.mjs'
+
+beforeEach(() => {
+  process.env.DSH_HOME = mkdtempSync(join(tmpdir(), 'dsh-sync-home-'))
+  clearScanCache()
+})
+
+afterEach(() => {
+  stopSyncTimer()
+})
+
+function ev(type, seq, data, extra = {}) {
+  return { type, seq, time: 1_700_000_000_000, data, ...extra }
+}
+
+function sampleEvents() {
+  return [
+    ev('session/imported', 0, { tool: 'dsh', sourceId: 'native-1', importedAt: 1 }, { ignorable: true }),
+    ev('turn/start', 1, { turn: 1 }),
+    ev('user/message', 2, {
+      id: 'u1', role: 'user', content: [{ type: 'text', text: '你好' }], source: { kind: 'user' },
+    }, { surfaceOp: 'append' }),
+    ev('assistant/message', 3, {
+      turn: 1, step: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: '收到' }] },
+    }, { surfaceOp: 'append' }),
+    ev('turn/end', 4, { turn: 1, reason: { kind: 'completed' } }),
+    ev('session/title', 5, { title: '测试会话', messageSeqs: [], source: { kind: 'user' } }),
+  ]
+}
+
+test('sync 配置默认关闭，保存后能读回开关', async () => {
+  const dir = join(process.env.DSH_HOME, 'dsh-chat-import')
+  const fresh = await loadSyncConfig(dir)
+  assert.equal(fresh.inbound.enabled, false)
+  assert.equal(fresh.outbound.enabled, false)
+  assert.equal(fresh.intervalMs, DEFAULT_INTERVAL_MS)
+  const saved = await saveSyncConfig(dir, {
+    inbound: { enabled: true, formats: ['claude'] },
+    outbound: { enabled: true, targets: ['codex', 'grokbuild'] },
+    intervalMs: 30_000,
+  })
+  assert.equal(saved.inbound.enabled, true)
+  assert.deepEqual(saved.inbound.formats, ['claude'])
+  assert.deepEqual(saved.outbound.targets, ['codex', 'grokbuild'])
+  const again = await loadSyncConfig(dir)
+  assert.equal(again.inbound.enabled, true)
+  assert.equal(again.intervalMs, 30_000)
+})
+
+test('Codex 往返：DSH 事件 → rollout JSONL → convertCodexJsonl 保住用户轮', () => {
+  const events = sampleEvents()
+  const out = serializeCodexJsonl({
+    meta: { id: 'native-1', createdAt: 1_700_000_000_000, cwd: '/tmp/proj' },
+    events,
+    sessionUuid: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    cwd: '/tmp/proj',
+  })
+  assert.match(out.jsonl, /session_meta/)
+  const back = convertCodexJsonl(out.jsonl, { sourcePath: '/tmp/rollout.jsonl' })
+  assert.equal(back.turns.length, 1)
+  assert.equal(back.turns[0].prompt, '你好')
+})
+
+test('Grok 往返：DSH 事件 → chat_history + summary → convertGrokbuildJson', () => {
+  const events = sampleEvents()
+  const out = serializeGrokbuildJsonl({
+    meta: { id: 'native-1', createdAt: 1_700_000_000_000, cwd: '/tmp/proj' },
+    events,
+  })
+  const summary = JSON.stringify(buildGrokSummary({
+    sessionUuid: '01a0048c-c8aa-7911-8be8-5959ab1fd2ec',
+    cwd: '/tmp/proj',
+    title: '测试会话',
+    createdAt: 1_700_000_000_000,
+    numMessages: 2,
+  }))
+  const back = convertGrokbuildJson(summary, out.jsonl, { sourcePath: '/tmp/grok-sess' })
+  assert.equal(back.turns.length, 1)
+  assert.equal(back.turns[0].prompt, '你好')
+})
+
+function makeRealCtx(root) {
+  const sessions = new Map()
+  const persistence = {
+    async list() { return [...sessions.values()].map((s) => s.meta) },
+    async create(meta) { sessions.set(meta.id, { meta, events: [] }) },
+    async append(id, events) {
+      const s = sessions.get(id)
+      for (const ev of events) s.events.push(ev)
+    },
+    async inspect(id) { return sessions.get(id) },
+    async readFrom(id, fromSeq = 0) {
+      const s = sessions.get(id)
+      return { meta: s.meta, events: s.events.slice(fromSeq) }
+    },
+  }
+  const webRoutes = []
+  const versionOf = (p) => {
+    try {
+      const s = statSync(p)
+      return 'v' + s.size + '-' + Math.trunc(s.mtimeMs)
+    } catch {
+      return 'missing'
+    }
+  }
+  const fs = {
+    async resolve(path) { return { targetKey: path, displayPath: path } },
+    async stat(target) {
+      try {
+        const s = statSync(target.targetKey)
+        return s.isDirectory()
+          ? { type: 'directory', size: 0, version: versionOf(target.targetKey), mtimeMs: s.mtimeMs }
+          : { type: 'file', size: s.size, version: versionOf(target.targetKey), mtimeMs: s.mtimeMs }
+      } catch {
+        return undefined
+      }
+    },
+    async readText(target) { return readFileSync(target.targetKey, 'utf8') },
+    async writeText(target, content, options) {
+      if (options && options.kind === 'replaceIfVersion') {
+        if (versionOf(target.targetKey) !== options.version) {
+          throw Object.assign(new Error('FS_STALE_VERSION'), { code: 'FS_STALE_VERSION' })
+        }
+      }
+      if (options && options.kind === 'createIfAbsent' && existsSync(target.targetKey)) {
+        throw Object.assign(new Error('EEXIST'), { code: 'EEXIST' })
+      }
+      mkdirSync(join(target.targetKey, '..'), { recursive: true })
+      writeFileSync(target.targetKey, content)
+      return { operation: 'update', version: versionOf(target.targetKey) }
+    },
+    async listDir(target) {
+      return readdirSync(target.targetKey, { withFileTypes: true }).map((e) => ({
+        name: e.name,
+        type: e.isDirectory() ? 'directory' : 'file',
+        target: { targetKey: join(target.targetKey, e.name), displayPath: join(target.targetKey, e.name) },
+      }))
+    },
+    processPath(target) { return target.targetKey },
+  }
+  const ctx = {
+    fs,
+    sessionPersistence: persistence,
+    webServer: { register(def) { webRoutes.push(def); return () => {} } },
+    get(name) {
+      if (name === 'sessionPersistence') return persistence
+      if (name === 'webServer') return ctx.webServer
+      if (name === 'workspaceRegistry') return { resolveByPath: async () => null, create: async () => ({ attachSession: async () => {} }), archivedSessionIds: [] }
+      return undefined
+    },
+    inject(_list, cb) { return cb(ctx) },
+    on() { return () => {} },
+    effect() { return () => {} },
+  }
+  return { ctx, persistence, sessions, webRoutes, root }
+}
+
+test('入站巡检：未导入 Claude 文件 → imported，再跑一轮 → skipped', async () => {
+  const home = process.env.DSH_HOME
+  const srcDir = join(home, 'claude-src')
+  mkdirSync(srcDir, { recursive: true })
+  const file = join(srcDir, 'sess-sync-001.jsonl')
+  writeFileSync(file, [
+    JSON.stringify({ sessionId: 'sess-sync-001', type: 'user', cwd: join(home, 'proj'), message: { role: 'user', content: '增量问题' } }),
+    JSON.stringify({ sessionId: 'sess-sync-001', type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: '增量回答' }] } }),
+  ].join('\n') + '\n')
+  const { ctx, sessions } = makeRealCtx(home)
+  const registryDir = join(home, 'dsh-chat-import')
+  await saveSyncConfig(registryDir, {
+    inbound: { enabled: true, formats: ['claude'] },
+    outbound: { enabled: false, targets: ['claude'] },
+  })
+  const first = await runSyncOnce(ctx, registryDir, { path: srcDir })
+  assert.equal(first.ok, true)
+  assert.equal(first.inbound.imported, 1)
+  assert.equal(sessions.size, 1)
+  const second = await runSyncOnce(ctx, registryDir, { path: srcDir })
+  assert.equal(second.inbound.imported, 0)
+  assert.ok(second.inbound.skipped >= 1)
+})
+
+test('出站写回：原生 DSH 会话落到 Codex 副本，再增量追加', async () => {
+  const home = process.env.DSH_HOME
+  const outRoot = join(home, 'codex-out')
+  mkdirSync(outRoot, { recursive: true })
+  const { ctx, persistence } = makeRealCtx(home)
+  const events = sampleEvents()
+  await persistence.create({ id: 'native-sync', createdAt: 1_700_000_000_000, cwd: join(home, 'proj') })
+  await persistence.append('native-sync', events)
+  const registryDir = join(home, 'dsh-chat-import')
+  await saveSyncConfig(registryDir, {
+    inbound: { enabled: false, formats: ['claude'] },
+    outbound: { enabled: true, targets: ['codex'], roots: { codex: outRoot } },
+  })
+  const first = await runSyncOnce(ctx, registryDir)
+  assert.equal(first.ok, true)
+  assert.equal(first.outbound.synced, 1)
+  const mapping = JSON.parse(readFileSync(join(registryDir, 'outbound.json'), 'utf8'))
+  const filePath = mapping.mappings['native-sync'].codex.filePath
+  assert.ok(existsSync(filePath))
+  const firstText = readFileSync(filePath, 'utf8')
+  assert.match(firstText, /你好/)
+
+  await persistence.append('native-sync', [
+    ev('turn/start', 6, { turn: 2 }),
+    ev('user/message', 7, {
+      id: 'u2', role: 'user', content: [{ type: 'text', text: '第二问' }], source: { kind: 'user' },
+    }, { surfaceOp: 'append' }),
+    ev('assistant/message', 8, {
+      turn: 2, step: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: '第二答' }] },
+    }, { surfaceOp: 'append' }),
+    ev('turn/end', 9, { turn: 2, reason: { kind: 'completed' } }),
+  ])
+  const second = await runSyncOnce(ctx, registryDir)
+  assert.equal(second.outbound.synced, 1)
+  const nextText = readFileSync(filePath, 'utf8')
+  assert.match(nextText, /第二问/)
+  assert.ok(nextText.length > firstText.length)
+})
+
+test('/api-import/sync GET 返回默认关闭状态', async () => {
+  const { ctx, webRoutes } = makeRealCtx(process.env.DSH_HOME)
+  const registryDir = join(process.env.DSH_HOME, 'dsh-chat-import')
+  registerSyncRoutes(ctx, ctx.webServer, registryDir)
+  const route = webRoutes.find((r) => r.path === '/api-import/sync')
+  assert.ok(route)
+  const chunks = []
+  const req = { method: 'GET', async *[Symbol.asyncIterator]() {} }
+  const res = {
+    writeHead() {},
+    end(body) { chunks.push(body) },
+  }
+  await route.handler(req, res)
+  const data = JSON.parse(chunks[0])
+  assert.equal(data.ok, true)
+  assert.equal(data.config.inbound.enabled, false)
+  assert.equal(data.config.outbound.enabled, false)
+})


### PR DESCRIPTION
## Why

`dsh-chat-import` already imports 14 sources and can write Claude sessions back with `sync_to_claude`. This adds the missing live loop:

- optional inbound watch for **new / grown** Claude, Codex, and Grok sessions
- optional outbound append/copy so those agents can pick up **new complete DSH turns**
- a **Sync** tab in the existing sidebar Import panel

Both directions stay **off by default**. The timer only starts after a switch is enabled. Outbound copies of native DSH sessions are recorded in `outbound.json` so inbound scans skip them (no echo loop). Existing Claude source writeback still uses the three-gate `sync_to_claude` path.

## What this is not

- Not a silent rewrite of `~/.claude` / `~/.codex` / `~/.grok`
- Cursor / Gemini / others stay import-only in this increment
- Outbound is a minimal re-importable format (text + tool calls), not a lossless private-field mirror

## Test plan

- [x] `node --test test/sync.test.mjs test/export.test.mjs`
- [x] `npm run check:linux`

Please take or leave any of this — happy to split inbound / outbound / UI if you prefer smaller reviews.