### PR TITLE
feat: 新增 mimocode（opencode fork）会话导入来源

### DIFF
--- a/convert.mjs
+++ b/convert.mjs
@@ -72,6 +72,10 @@ export {
 } from './lib/convert/opencode.mjs'
 
 export {
+  convertMimocodeJson,
+} from './lib/convert/mimocode.mjs'
+
+export {
   convertZcodeJson,
 } from './lib/convert/zcode.mjs'
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -182,12 +182,12 @@ window.__ModuleLoader__.load({
     // claude）。chatgpt 无默认数据根，仅显式 path 可发现。
     const SOURCES = [
       "", "claude-code", "codex", "chatgpt", "cursor", "gemini", "reasonix",
-      "opencode", "zcode", "grokbuild", "openclaw", "pi", "hermes", "kimi", "qoder", "dsh",
+      "opencode", "mimocode", "zcode", "grokbuild", "openclaw", "pi", "hermes", "kimi", "qoder", "dsh",
     ];
     // discovery format 短名 → 客户端来源 id（构建 /api-import/import 的 items）。
     const FORMAT_SOURCE = {
       claude: "claude-code", codex: "codex", chatgpt: "chatgpt", cursor: "cursor",
-      gemini: "gemini", reasonix: "reasonix", opencode: "opencode", zcode: "zcode",
+      gemini: "gemini", reasonix: "reasonix", opencode: "opencode", mimocode: "mimocode", zcode: "zcode",
       grokbuild: "grokbuild", openclaw: "openclaw", pi: "pi", hermes: "hermes",
       kimi: "kimi", qoder: "qoder", dsh: "dsh",
     };

--- a/lib/command.mjs
+++ b/lib/command.mjs
@@ -33,6 +33,7 @@ const TOOL_FORMAT = {
   gemini: 'gemini', import_gemini: 'gemini',
   reasonix: 'reasonix', import_reasonix: 'reasonix',
   opencode: 'opencode', import_opencode: 'opencode',
+  mimocode: 'mimocode', import_mimocode: 'mimocode',
   zcode: 'zcode', import_zcode: 'zcode',
   grokbuild: 'grokbuild', import_grokbuild: 'grokbuild',
   openclaw: 'openclaw', import_openclaw: 'openclaw',
@@ -43,7 +44,7 @@ const TOOL_FORMAT = {
   dsh: 'dsh', import_dsh: 'dsh',
 }
 
-const SOURCE_NAMES = 'claude/codex/chatgpt/cursor/gemini/reasonix/opencode/zcode/grokbuild/openclaw/pi/hermes/kimi/qoder/dsh'
+const SOURCE_NAMES = 'claude/codex/chatgpt/cursor/gemini/reasonix/opencode/mimocode/zcode/grokbuild/openclaw/pi/hermes/kimi/qoder/dsh'
 
 // 把导入结果压成人类可读文本（对齐 import_* 工具 render 的语义：批量计数 +
 // 前 5 条失败/跳过明细；单文件按 status 区分）。

--- a/lib/convert/mimocode.mjs
+++ b/lib/convert/mimocode.mjs
@@ -1,0 +1,15 @@
+// lib/convert/mimocode.mjs — mimocode 历史库会话 → DSH 会话（纯函数）
+//
+// mimocode 是 opencode 的 fork：SQLite 三表（session/message/part）schema 同构、
+// 消息/part 数据 JSON 结构与 opencode 完全一致，仅 provider 标签不同。转换直接
+// 复用 lib/convert/opencode.mjs 的 convertOpencodeJson，只覆盖 provider 为
+// 'mimocode'（事件里 session/imported.data.tool 与模型 source.provider 的标注）。
+// 独立成文件保持「每源一个 convert 文件」的仓库惯例，opencode 转换器不含任何
+// mimocode 专属分支。
+
+import { convertOpencodeJson } from './opencode.mjs'
+
+/** mimocode 会话（opencode fork）→ DSH 会话：复用 opencode 转换器，仅换 provider 标签。 */
+export function convertMimocodeJson(raw, args = {}) {
+  return convertOpencodeJson(raw, { ...args, provider: 'mimocode' })
+}

--- a/lib/convert/opencode.mjs
+++ b/lib/convert/opencode.mjs
@@ -129,7 +129,9 @@ export function convertOpencodeJson(raw, args = {}) {
     meta,
     turns: seedTurns,
     title,
-    provider: 'opencode',
+    // mimocode 是 opencode 的 fork，复用本转换器时经 args.provider 覆盖标签
+    //（lib/convert/mimocode.mjs 的 convertMimocodeJson 传 provider='mimocode'）。
+    provider: args.provider || 'opencode',
     model: opencodeSessionModel(chat),
     skipped: 0,
     records: chat.messages.length,

--- a/lib/discovery-host.mjs
+++ b/lib/discovery-host.mjs
@@ -9,6 +9,7 @@
 import { join } from 'node:path'
 import { discoverSessions } from './discovery.mjs'
 import { readOpencodeDb } from './opencode.mjs'
+import { readMimocodeDb } from './mimocode.mjs'
 import { readZcodeDb } from './zcode.mjs'
 import { readHermesDb } from './hermes.mjs'
 import { loadImports, archivedSessionIds } from './imports.mjs'
@@ -19,6 +20,11 @@ function dbSessionSummaries(kind, dbPath) {
   try {
     if (kind === 'opencode') {
       return readOpencodeDb(dbPath).map((s) => dbSummary(s, 'createdAt'))
+    }
+    // mimocode 是 opencode fork（schema 同构），readMimocodeDb 复用通用读取器并
+    // 剔除 MiMo 后台任务会话（checkpoint-writer / AutoDream / AutoDistill）
+    if (kind === 'mimocode') {
+      return readMimocodeDb(dbPath).map((s) => dbSummary(s, 'createdAt'))
     }
     if (kind === 'zcode') {
       return readZcodeDb(dbPath).map((s) => dbSummary(s, 'createdAt'))

--- a/lib/discovery.mjs
+++ b/lib/discovery.mjs
@@ -56,7 +56,7 @@ import { readFileSync, statSync } from 'node:fs'
 import { decompress } from 'fzstd'
 
 export const FORMATS = [
-  'claude', 'codex', 'cursor', 'gemini', 'reasonix', 'opencode',
+  'claude', 'codex', 'cursor', 'gemini', 'reasonix', 'opencode', 'mimocode',
   'zcode', 'grokbuild', 'openclaw', 'pi', 'hermes', 'kimi', 'qoder', 'chatgpt', 'dsh',
 ]
 
@@ -84,6 +84,7 @@ export function defaultRoots({ home = homedir() } = {}) {
       ? [join(home, '.reasonix', 'sessions'), reasonixDesktop]
       : join(home, '.reasonix', 'sessions'),
     opencode: join(home, '.local', 'share', 'opencode', 'opencode.db'),
+    mimocode: join(home, '.local', 'share', 'mimocode', 'mimocode.db'),
     zcode: join(home, '.zcode', 'cli', 'db', 'db.sqlite'),
     grokbuild: [join(home, '.grok', 'sessions'), join(home, '.grok', 'archived_sessions')],
     openclaw: join(home, '.openclaw', 'agents'),
@@ -725,6 +726,7 @@ async function scanSqlite(host, format, target, dbName, bm) {
   })
 }
 function scanOpencode(host, target, bm) { return scanSqlite(host, 'opencode', target, 'opencode.db', bm) }
+function scanMimocode(host, target, bm) { return scanSqlite(host, 'mimocode', target, 'mimocode.db', bm) }
 function scanZcode(host, target, bm) { return scanSqlite(host, 'zcode', target, 'db.sqlite', bm) }
 
 // grokbuild：~/.grok/sessions/<project>/<session_id>/（含 archived_sessions/），
@@ -1220,6 +1222,7 @@ const SCANNERS = {
   gemini: scanGemini,
   reasonix: scanReasonix,
   opencode: scanOpencode,
+  mimocode: scanMimocode,
   zcode: scanZcode,
   grokbuild: scanGrokbuild,
   openclaw: scanOpenclaw,
@@ -1268,6 +1271,7 @@ function fileFormatsForPath(path) {
   if (/\.json$/i.test(lower)) return ['gemini', 'chatgpt']
   if (/\.db$/i.test(lower)) {
     if (/opencode\.db$/i.test(lower)) return ['opencode']
+    if (/mimocode\.db$/i.test(lower)) return ['mimocode']
     if (/db\.sqlite$/i.test(lower)) return ['zcode']
     if (/state\.db$/i.test(lower)) return ['hermes']
     return ['opencode', 'zcode', 'hermes']

--- a/lib/import-variants.mjs
+++ b/lib/import-variants.mjs
@@ -13,7 +13,7 @@ import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 import {
   convertChatgptJson, convertGrokbuildJson, convertHermesJson, convertKimiWire,
-  convertOpencodeJson, convertZcodeJson,
+  convertOpencodeJson, convertMimocodeJson, convertZcodeJson,
 } from '../convert.mjs'
 import { markTrimmedSource } from './budget.mjs'
 import {
@@ -26,6 +26,7 @@ import {
 } from './imports.mjs'
 import { readHermesDb } from './hermes.mjs'
 import { readOpencodeDb } from './opencode.mjs'
+import { readMimocodeDb } from './mimocode.mjs'
 import { readZcodeDb, readZcodeTranscript, zcodeDefaultDbPath } from './zcode.mjs'
 
 // ── ChatGPT 导出导入：单个 conversations.json 可能含多个会话，每个会话独立落盘
@@ -706,6 +707,31 @@ export async function previewOpencodeDirectory(ctx, dirTarget, args) {
   const dirPath = dirTarget.displayPath || ctx.fs.processPath(dirTarget)
   const dbTarget = await ctx.fs.resolve(join(dirPath, 'opencode.db'))
   return previewOpencodeFile(ctx, dbTarget, args)
+}
+
+// mimocode 预览：opencode fork，同构 SQLite 只读重演（readMimocodeDb 已兼容无 model
+// 列 schema 并默认剔除后台任务会话），provider 标签为 mimocode。
+export async function previewMimocodeFile(ctx, target, args) {
+  const path = target.displayPath || ctx.fs.processPath(target)
+  const sessions = readMimocodeDb(path, { fullHistory: args.fullHistory === true })
+  const wanted = Array.isArray(args.sessionIds) && args.sessionIds.length > 0 ? new Set(args.sessionIds) : null
+  const results = []
+  for (const s of sessions) {
+    if (wanted && !wanted.has(s.id)) continue
+    const out = markTrimmedSource(convertMimocodeJson(JSON.stringify(s), { ...args, sourcePath: path }), args)
+    if (!out.meta || (out.turns.length === 0 && out.events.length === 0)) {
+      results.push({ path, skipped: 1, skipReason: 'no user turns (session ' + s.id + ')' })
+      continue
+    }
+    results.push({ path, ...previewEntry(out) })
+  }
+  return { total: sessions.length, results }
+}
+
+export async function previewMimocodeDirectory(ctx, dirTarget, args) {
+  const dirPath = dirTarget.displayPath || ctx.fs.processPath(dirTarget)
+  const dbTarget = await ctx.fs.resolve(join(dirPath, 'mimocode.db'))
+  return previewMimocodeFile(ctx, dbTarget, args)
 }
 
 // zcode 预览：db.sqlite / transcript.jsonl 回退 / zcode://<id> 伪路径，同源只读重演

--- a/lib/mimocode.mjs
+++ b/lib/mimocode.mjs
@@ -1,0 +1,65 @@
+// lib/mimocode.mjs — mimocode SQLite 历史库读取与导入编排（opencode fork 专属）
+//
+// mimocode 是 opencode 的 fork：历史库为 SQLite（默认 ~/.local/share/mimocode/
+// mimocode.db），session/message/part 三表 schema 与 opencode 同构（唯一差异：
+// session 表无 model 列，消息级 model 在 message.data.modelID）。读取/导入/编排
+// 完全复用 lib/opencode.mjs 的通用实现，本文件只收 mimocode 专属差异：
+//   - 库文件名 mimocode.db（目录模式定位）
+//   - provider 标签 mimocode（lib/convert/mimocode.mjs）
+//   - 剔除 MiMo 后台任务会话（checkpoint-writer / AutoDream / AutoDistill），
+//     isMimocodeBackgroundSession 判定后作为 filter 传入 readOpencodeDb
+//   - 无 model 列的 schema 由 readOpencodeDb 按 PRAGMA 探测自动兼容
+//
+// 保持「每源一个编排文件」的仓库惯例（对照 lib/zcode.mjs / lib/hermes.mjs），
+// opencode 编排文件不含任何 mimocode 专属分支。
+
+import { join } from 'node:path'
+import { importOpencodeFile, importOpencodeDirectory, readOpencodeDb } from './opencode.mjs'
+
+/** mimocode 历史库默认文件名（目录模式定位用）。 */
+export const MIMOCODE_DB_NAME = 'mimocode.db'
+
+// mimocode 后台任务会话特征（2026-08-18 实测 mimocode.db）：
+//   checkpoint-writer —— 标题前缀 "checkpoint-writer: ..."（全库 822 条），消息 agent=checkpoint-writer
+//   AutoDream        —— 标题 "Auto Dream"（4 条），消息 agent=dream（156 条）
+//   AutoDistill      —— 标题 "Auto Distill"（1 条），消息 agent=distill（7 条）
+// 这些是 MiMo 的记忆巩固/工作流蒸馏后台任务，无用户交互价值，导入/发现时剔除。
+// 标题用空格分隔（Auto Dream/Auto Distill），因此标题正则与 agent 集合双信号判定。
+const MIMOCODE_BG_TITLE = /^(checkpoint[-_ ]?writer|auto[-_ ]?(dream|distill))\b/i
+const MIMOCODE_BG_AGENTS = new Set(['checkpoint-writer', 'dream', 'distill'])
+
+/** mimocode 后台任务会话判定（纯函数）：标题前缀或任一条消息 agent 命中即真。 */
+export function isMimocodeBackgroundSession(session) {
+  if (!session || typeof session !== 'object') return false
+  if (typeof session.title === 'string' && MIMOCODE_BG_TITLE.test(session.title.trim())) return true
+  if (Array.isArray(session.messages)) {
+    for (const m of session.messages) {
+      if (m && typeof m.agent === 'string' && MIMOCODE_BG_AGENTS.has(m.agent.toLowerCase())) return true
+    }
+  }
+  return false
+}
+
+// mimocode 历史库（SQLite）→ 中间会话 JSON 数组：复用 opencode 读取器，默认剔除
+// 后台任务会话（options.filter 覆盖时以显式值为准；fullHistory 语义与 opencode 一致）。
+export function readMimocodeDb(dbPath, options = {}) {
+  return readOpencodeDb(dbPath, {
+    fullHistory: options.fullHistory === true,
+    filter: options.filter === undefined ? isMimocodeBackgroundSession : options.filter,
+  })
+}
+
+// mimocode 单库导入：复用 opencode 编排（importOpencodeFile），恒返回批量形态；
+// 默认剔除后台任务会话（filter 透传给 readOpencodeDb）。
+export async function importMimocodeFile(ctx, target, args, options = {}) {
+  return importOpencodeFile(ctx, target, args, { ...options, filter: isMimocodeBackgroundSession })
+}
+
+// mimocode 目录导入：目录里定位 mimocode.db（无递归），再走单库导入；缺 DB 时抛错。
+export async function importMimocodeDirectory(ctx, dirTarget, args, options = {}) {
+  return importOpencodeDirectory(ctx, dirTarget, args, {
+    ...options,
+    dbName: MIMOCODE_DB_NAME,
+    filter: isMimocodeBackgroundSession,
+  })
+}

--- a/lib/opencode.mjs
+++ b/lib/opencode.mjs
@@ -25,8 +25,14 @@ import { loadImports, unwrapRecord, listPersistedIds, archivedSessionIds, argsFi
 export function readOpencodeDb(dbPath, options = {}) {
   const db = new DatabaseSync(dbPath, { readOnly: true })
   try {
+    // mimocode（opencode fork）的 session 表没有 model 列：按表结构探测决定是否
+    // SELECT model，兼容两种 schema（opencode 有 model 列、mimocode 无）。
+    const sessionCols = new Set(db.prepare('PRAGMA table_info(session)').all().map((c) => c.name))
+    const sessionSelect = sessionCols.has('model')
+      ? 'SELECT id, title, directory, time_created, model FROM session ORDER BY time_created, id'
+      : 'SELECT id, title, directory, time_created FROM session ORDER BY time_created, id'
     const sessions = []
-    const sessionRows = db.prepare('SELECT id, title, directory, time_created, model FROM session ORDER BY time_created, id').all()
+    const sessionRows = db.prepare(sessionSelect).all()
     for (const row of sessionRows) {
       const messages = db.prepare('SELECT id, time_created, data FROM message WHERE session_id = ? ORDER BY time_created, id').all(row.id)
       const partsByMessage = new Map()
@@ -42,6 +48,9 @@ export function readOpencodeDb(dbPath, options = {}) {
           role: data.role,
           createdAt: m.time_created,
           cwd: typeof path.cwd === 'string' ? path.cwd : undefined,
+          // mimocode 后台任务会话（checkpoint-writer / dream / distill）经 agent 识别，
+          // 供 isMimocodeBackgroundSession 过滤（opencode 路径忽略该字段）。
+          agent: typeof data.agent === 'string' ? data.agent : undefined,
           model: typeof data.modelID === 'string' ? data.modelID
             : data.model && typeof data.model === 'object' && typeof data.model.modelID === 'string' ? data.model.modelID
               : undefined,
@@ -74,7 +83,7 @@ export function readOpencodeDb(dbPath, options = {}) {
           }
         }
       }
-      sessions.push({
+      const session = {
         id: row.id,
         title: row.title,
         directory: row.directory,
@@ -82,7 +91,12 @@ export function readOpencodeDb(dbPath, options = {}) {
         model: parseOpencodeSessionModel(row.model),
         summary,
         messages: exportMsgs.map(({ isSummary, ...rest }) => rest),
-      })
+      }
+      // options.filter（剔除谓词——返回 true 的会话不进入结果集）：opencode 默认不过滤；
+      // mimocode 经 lib/mimocode.mjs 传入 isMimocodeBackgroundSession 剔除后台任务会话。
+      // 导入/预览/发现共用 readOpencodeDb，一处过滤全覆盖。
+      if (typeof options.filter === 'function' && options.filter(session)) continue
+      sessions.push(session)
     }
     return sessions
   } finally {
@@ -111,7 +125,7 @@ function parseOpencodeSessionModel(raw) {
 // 逐会话判增 append / compaction 使轮次变少 → sourceShrunk。
 // sourcePath 为 opencode.db 路径（目录模式定位后同样落到 db 文件）。
 // runDecision / markTrimmedSource 由 index.mjs 注入（其他导入路径共用，见文件头）。
-export async function importOpencodeFile(ctx, target, args, { registryDir, persisted, runDecision, markTrimmedSource } = {}) {
+export async function importOpencodeFile(ctx, target, args, { registryDir, persisted, runDecision, markTrimmedSource, filter } = {}) {
   const persistedSet = persisted ?? await listPersistedIds(ctx)
   const archivedIds = archivedSessionIds(ctx)
   const path = target.displayPath || ctx.fs.processPath(target)
@@ -147,7 +161,7 @@ export async function importOpencodeFile(ctx, target, args, { registryDir, persi
     }
   }
 
-  const sessions = readOpencodeDb(path, { fullHistory: args.fullHistory === true })
+  const sessions = readOpencodeDb(path, { fullHistory: args.fullHistory === true, filter: options.filter })
   const wanted = Array.isArray(args.sessionIds) && args.sessionIds.length > 0 ? new Set(args.sessionIds) : null
   const items = []
   const preSkipped = []
@@ -173,9 +187,12 @@ export async function importOpencodeFile(ctx, target, args, { registryDir, persi
 }
 
 // opencode 目录导入：目录里定位 opencode.db（无递归），再走单库导入；缺 DB 时抛错。
-export async function importOpencodeDirectory(ctx, dirTarget, args, { registryDir, persisted, runDecision, markTrimmedSource } = {}) {
+// 库文件名经 options.dbName 参数化（默认 opencode.db），mimocode fork 场景由
+// lib/mimocode.mjs 的 importMimocodeDirectory 传入 mimocode.db 与后台会话过滤；
+// options.filter 透传给 readOpencodeDb（剔除谓词，见 readOpencodeDb）。
+export async function importOpencodeDirectory(ctx, dirTarget, args, { registryDir, persisted, runDecision, markTrimmedSource, dbName = 'opencode.db', filter } = {}) {
   const dirPath = dirTarget.displayPath || ctx.fs.processPath(dirTarget)
-  const dbPath = join(dirPath, 'opencode.db')
+  const dbPath = join(dirPath, dbName)
   const dbTarget = await ctx.fs.resolve(dbPath)
-  return importOpencodeFile(ctx, dbTarget, args, { registryDir, persisted, runDecision, markTrimmedSource })
+  return importOpencodeFile(ctx, dbTarget, args, { registryDir, persisted, runDecision, markTrimmedSource, filter })
 }

--- a/lib/panel.mjs
+++ b/lib/panel.mjs
@@ -32,6 +32,7 @@ const SOURCE_FORMAT = {
   gemini: 'gemini',
   reasonix: 'reasonix',
   opencode: 'opencode',
+  mimocode: 'mimocode',
   zcode: 'zcode',
   grokbuild: 'grokbuild',
   openclaw: 'openclaw',
@@ -58,7 +59,7 @@ export async function importDiscoveryItem(ctx, format, sourcePath, sessionIds, {
   const importBatch = io.dir
     || ((c, d, a) => importDirectory(c, d, a, { convert: spec.convert, sourceLabel: spec.sourceLabel, deriveArgs, collect: spec.derive && spec.derive.collect, registryDir: reg.dir, fingerprintKeys: reg.fingerprintKeys || [] }))
   const args = { path: sourcePath, force: force === true, budget, budgetSource }
-  if (Array.isArray(sessionIds) && sessionIds.length > 0 && (format === 'opencode' || format === 'zcode')) {
+  if (Array.isArray(sessionIds) && sessionIds.length > 0 && (format === 'opencode' || format === 'mimocode' || format === 'zcode')) {
     args.sessionIds = [...new Set(sessionIds)]
   }
   const target = await ctx.fs.resolve(sourcePath)
@@ -188,7 +189,7 @@ export function registerPanelRoutes(ctx, ws, registryDir) {
             group = { format, sourcePath, sessionIds: [] }
             byPath.set(sourcePath, group)
           }
-          if ((format === 'opencode' || format === 'zcode') && typeof item.sessionId === 'string' && item.sessionId) {
+          if ((format === 'opencode' || format === 'mimocode' || format === 'zcode') && typeof item.sessionId === 'string' && item.sessionId) {
             group.sessionIds.push(item.sessionId)
           }
         }

--- a/lib/tools.mjs
+++ b/lib/tools.mjs
@@ -14,14 +14,15 @@ import { join } from 'node:path'
 import {
   convertClaudeJsonl, convertCodexJsonl, convertChatgptJson, convertCursorJsonl,
   convertGeminiJson, convertReasonixJsonl, convertPiJsonl, convertOpencodeJson,
-  convertZcodeJson, convertGrokbuildJson, convertOpenclawJson, convertHermesJson,
-  convertKimiWire, convertQoderJsonl, convertDshJsonl, convertLocalJsonl,
+  convertMimocodeJson, convertZcodeJson, convertGrokbuildJson, convertOpenclawJson,
+  convertHermesJson, convertKimiWire, convertQoderJsonl, convertDshJsonl, convertLocalJsonl,
 } from '../convert.mjs'
 import { openclawDisplayNames } from './convert/openclaw.mjs'
 import { markTrimmedSource } from './budget.mjs'
 import { runDecision, collectJsonFiles } from './import-core.mjs'
 import { syncClaudeSession } from './backfill.mjs'
 import { importOpencodeFile, importOpencodeDirectory } from './opencode.mjs'
+import { importMimocodeFile, importMimocodeDirectory } from './mimocode.mjs'
 import { importZcodeFile, importZcodeDirectory } from './zcode.mjs'
 import { FORMATS } from './discovery.mjs'
 import { makeImportTool } from './toolkit.mjs'
@@ -35,6 +36,7 @@ import {
   previewHermesFile, previewHermesDirectory,
   previewKimiFile, previewKimiDirectory,
   previewOpencodeFile, previewOpencodeDirectory,
+  previewMimocodeFile, previewMimocodeDirectory,
   previewZcodeFile, previewZcodeDirectory,
 } from './import-variants.mjs'
 import { exportClaudeSession, exportBundleSession, exportCodexSession, exportKimiSession } from './export-tool.mjs'
@@ -276,6 +278,54 @@ export function registerTools(ctx, registryDir) {
     description:
       '从 opencode 的 SQLite 历史库 opencode.db 导入历史会话为可继续的 DSH 会话（默认位置 ~/.local/share/opencode/opencode.db）。' +
       'path 可以是 .db 文件，也可以是包含 opencode.db 的数据目录（目录模式自动定位，无递归）。' +
+      '读取 session/message/part 表重建对话（event 表是部分镜像、session_message/session_input 为空，忽略）；' +
+      '文本/reasoning/工具调用（tool/call + tool/result，含错误标记与 sourceEventSeqs 关联）/图片附件/补丁/子任务完整保留；' +
+      '默认尊重对话压缩（compaction，只导最后一次摘要+尾巴，摘要作 reasoning 块前置），可选 fullHistory 导全量；' +
+      '可选 sessionIds 只导指定源会话；重复导入同一会话会幂等跳过。返回批量统计与逐会话明细。',
+  }))
+  // mimocode 源：mimocode 是 opencode 的 fork（SQLite 三表 schema 同构，仅 session 表
+  // 无 model 列、库文件名不同），读取/导入/预览复用 opencode 管线——mimocode 专属
+  // 差异（mimocode.db、provider 标签、后台任务会话过滤）收在 lib/mimocode.mjs /
+  // lib/convert/mimocode.mjs。默认位置 ~/.local/share/mimocode/mimocode.db。
+  ctx.tools.register(makeImportTool(ctx, {
+    format: 'mimocode',
+    toolName: 'import_mimocode',
+    sourceLabel: 'mimocode',
+    convert: convertMimocodeJson,
+    // 一库多会话：单 .db 文件也恒返回批量形态；目录模式自动定位 mimocode.db（无递归）；
+    // 导入时剔除 MiMo 后台任务会话（checkpoint-writer / AutoDream / AutoDistill）
+    io: {
+      file: (c, t, a) => importMimocodeFile(c, t, a, { registryDir, runDecision, markTrimmedSource }),
+      dir: (c, d, a) => importMimocodeDirectory(c, d, a, { registryDir, runDecision, markTrimmedSource }),
+      previewFile: (c, t, a) => previewMimocodeFile(c, t, a),
+      previewDir: (c, d, a) => previewMimocodeDirectory(c, d, a),
+      alwaysBatch: true,
+    },
+    registry: { dir: registryDir },
+    // mimocode 无单会话 id 覆盖、无递归（目录里就是 mimocode.db）
+    schema: {
+      drop: ['sessionId', 'recursive'],
+      extra: {
+        sessionIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '可选：只导入指定源会话 id（缺省导入全部会话）。',
+        },
+        fullHistory: {
+          type: 'boolean',
+          description: '可选：true 时导入全量历史（忽略 mimocode 的对话压缩）；默认 false（尊重压缩：只导最后一次摘要 + 尾巴）。',
+        },
+      },
+    },
+    label: {
+      path: 'mimocode 历史数据库（mimocode.db）的文件路径，或包含 mimocode.db 的数据目录路径。',
+      batch: '会话',
+      skipped: '无用户回合',
+    },
+    description:
+      '从 mimocode 的 SQLite 历史库 mimocode.db 导入历史会话为可继续的 DSH 会话（默认位置 ~/.local/share/mimocode/mimocode.db；' +
+      'mimocode 是 opencode 的 fork，会话存储格式与 opencode 一致）。' +
+      'path 可以是 .db 文件，也可以是包含 mimocode.db 的数据目录（目录模式自动定位，无递归）。' +
       '读取 session/message/part 表重建对话（event 表是部分镜像、session_message/session_input 为空，忽略）；' +
       '文本/reasoning/工具调用（tool/call + tool/result，含错误标记与 sourceEventSeqs 关联）/图片附件/补丁/子任务完整保留；' +
       '默认尊重对话压缩（compaction，只导最后一次摘要+尾巴，摘要作 reasoning 块前置），可选 fullHistory 导全量；' +


### PR DESCRIPTION
## 概述

mimocode 是 opencode 的 fork（MiMo CLI），历史库为 SQLite（默认 `~/.local/share/mimocode/mimocode.db`），`session`/`message`/`part` 三表 schema 与 opencode 同构，仅一处差异：**`session` 表没有 `model` 列**（opencode 有），消息级模型信息在 `message.data.modelID`。

本 PR 为 dsh-chat-import 新增 mimocode 导入来源，读取/导入/预览**复用 opencode 通用管线**，mimocode 专属差异收在独立文件（对照 zcode/hermes 的「每源一个文件」惯例）。

## 改动

**新增文件**
- `lib/mimocode.mjs` — mimocode 专属编排：`MIMOCODE_DB_NAME`、`isMimocodeBackgroundSession`（后台任务会话判定）、`readMimocodeDb` / `importMimocodeFile` / `importMimocodeDirectory`
- `lib/convert/mimocode.mjs` — `convertMimocodeJson`（复用 `convertOpencodeJson`，仅覆盖 provider 标签）

**修改文件（opencode 通用增强，不影响既有行为）**
- `lib/opencode.mjs` — `readOpencodeDb` 按 `PRAGMA table_info(session)` 探测是否含 `model` 列（兼容两种 schema）；新增可选 `filter` 剔除谓词参数；消息增加 `agent` 字段
- `lib/tools.mjs` — 注册 `import_mimocode` 工具（`format: 'mimocode'`，含 `sessionIds` / `fullHistory` 参数）
- `lib/import-variants.mjs` — `previewMimocodeFile` / `previewMimocodeDirectory` dry-run 预览
- `lib/discovery.mjs` / `lib/discovery-host.mjs` — `mimocode` 加入 FORMATS、默认数据根、扫描器与发现摘要
- `lib/command.mjs` / `lib/panel.mjs` — `/import mimocode` 命令与面板来源映射、sessionIds 过滤
- `lib/client.js` — 面板「来源」下拉补充 mimocode 选项
- `convert.mjs` — re-export `convertMimocodeJson`

## 后台任务会话过滤

mimocode 的 MiMo 记忆系统会生成后台任务会话（无用户交互价值），导入与发现时默认剔除（双信号判定）：
- **checkpoint-writer**：标题前缀 `checkpoint-writer: ...`，消息 `agent=checkpoint-writer`
- **AutoDream**：标题 `Auto Dream`，消息 `agent=dream`
- **AutoDistill**：标题 `Auto Distill`，消息 `agent=distill`

## 验证

- 真实 mimocode.db（1077 会话，513MB）端到端：`readOpencodeDb` 7.3s 读取全量；`convertMimocodeJson` 正常产出 DSH 事件（`imported.tool: 'mimocode'`）
- 过滤实测：1077 → 249 个正常会话，剔除的 828 个全部命中后台判定
- opencode 路径不受影响（`readOpencodeDb(opencode.db)` 589 会话全量、转换标签仍为 `opencode`）