### PR TITLE
fix(client): 修复侧边栏「导入会话」与「插件市场」按钮布局冲突

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -776,42 +776,67 @@ window.__ModuleLoader__.load({
           fill: "currentColor" }));
     }
 
-    /** 触发按钮：fixed 浮动（脱离 footer.action 行布局），视觉对齐侧边栏「设置」按钮。
-     * footerActions 是 256px flex 行；官方 cordis 徽标条目 `flex:0 0 auto; width:256px`
-     * 不可收缩、占满整行，会把同槽其它条目挤出容器并被侧边栏 overflow:hidden 裁剪、
-     * 主内容列遮挡（实测）。用 fixed + 高 z-index 把按钮锚到侧边栏底部上方，任何
-     * footer occupant（cordis / 未来其它插件）都无法挡住；样式对齐设置按钮（透明底、
-     * 12px 圆角、16px 图标 + 文字、悬停浅底），图标用插件 logo；rail（wide=false）
-     * 态只显图标。
+    /** 触发按钮：footer 行内出现整行占用者（官方 cordis 徽标 / 内置插件市场
+     * launcher）时 fixed 浮动（脱离 footer.action 行布局），锚定到占用者正上方
+     * 独占一行、左缘与宽度对齐，形成并行两行；无占用者时落回行内全宽条目。
+     * footerActions 是不换行的 256px flex 行；cordis 徽标 `flex:0 0 auto;
+     * width:256px`、市场 launcher `flex:none; width:calc(100% + 4px)` 均不可
+     * 收缩、占满整行，会把同槽其它条目挤出容器并被侧边栏 overflow:hidden 裁剪、
+     * 或挤成竖排窄条（实测）。fixed + 高 z-index 让任何 footer occupant 都挡不
+     * 住；样式对齐设置按钮（透明底、12px 圆角、16px 图标 + 文字、悬停浅底），
+     * 图标用插件 logo；rail（wide=false）态只显图标。
      */
-    /** 检测官方 cordis 徽标是否可见（占满 footer 行的 `flex:none; width:256px` 条目）：
-     * 可见 → 我们的条目会被挤出裁剪，需要浮层；隐藏/缺席 → 可落回 footer 行内。 */
-    const cordisBadgeVisible = () => {
-      if (typeof document === "undefined") return false;
-      const el = document.querySelector("[data-cordis-badge]");
-      if (!el) return false;
-      const cs = getComputedStyle(el);
-      if (cs.display === "none" || cs.visibility === "hidden" || cs.opacity === "0") return false;
-      return el.getBoundingClientRect().width > 0;
+    /** 检测 footer 行内的「整行占用者」：官方 cordis 徽标（[data-cordis-badge]，
+     * `flex:none; width:256px`）与内置插件市场 launcher（.dshMarketLauncher，
+     * `flex:none; width:calc(100% + 4px)`）都会占满不换行的 footer flex 行，
+     * 把同槽其它条目挤成窄条/竖排文字。返回最靠上的一个可见占用者的视口坐标
+     * （{top,left,width,height}），无则 null —— 用于把本按钮浮到其上方独占
+     * 一行、左缘与宽度对齐，与占用者形成并行两行布局。 */
+    const footerOccupantRect = () => {
+      if (typeof document === "undefined") return null;
+      let best = null;
+      for (const sel of ["[data-cordis-badge]", ".dshMarketLauncher"]) {
+        const el = document.querySelector(sel);
+        if (!el) continue;
+        const cs = getComputedStyle(el);
+        if (cs.display === "none" || cs.visibility === "hidden" || cs.opacity === "0") continue;
+        const r = el.getBoundingClientRect();
+        if (r.width <= 0 || r.height <= 0) continue;
+        if (!best || r.top < best.top) best = { top: r.top, left: r.left, width: r.width, height: r.height };
+      }
+      return best;
     };
 
     function ImportButton({ wide }) {
       const t = useTranslate();
       const [open, setOpen] = useState(false);
       const rail = wide === false;
-      // cordis 徽标在场（占满 footer 行）→ fixed 浮层；徽标隐藏/缺席 → 落回 footer
-      // 行内（普通 footer 条目，全宽）。MutationObserver 跟踪徽标增删/显隐。
-      const [floating, setFloating] = useState(() => cordisBadgeVisible());
+      // footer 行内有整行占用者（cordis 徽标 / 插件市场 launcher）→ fixed 浮层
+      // 独占一行，锚定到占用者正上方、左缘与宽度与之对齐（并行两行，互不挤压）；
+      // 无占用者 → 落回 footer 行内（普通全宽条目）。MutationObserver + resize
+      // 跟踪占用者的增删/显隐/位移；setAnchor 做等值比较防止观察自身 DOM 变化
+      // 造成重渲染循环。
+      const [anchor, setAnchor] = useState(() => footerOccupantRect());
       useEffect(() => {
-        const check = () => setFloating(cordisBadgeVisible());
+        const check = () => {
+          const next = footerOccupantRect();
+          setAnchor((prev) => {
+            if (!prev && !next) return prev;
+            if (prev && next && prev.top === next.top && prev.left === next.left
+              && prev.width === next.width && prev.height === next.height) return prev;
+            return next;
+          });
+        };
         check();
         const mo = new MutationObserver(check);
         mo.observe(document.body, {
           childList: true, subtree: true, attributes: true,
           attributeFilter: ["data-cordis-badge", "style", "class"],
         });
-        return () => mo.disconnect();
+        window.addEventListener("resize", check);
+        return () => { mo.disconnect(); window.removeEventListener("resize", check); };
       }, []);
+      const floating = !!anchor;
       // 视觉逐项对齐侧边栏「设置」按钮（实测基准）：行高 22px、内边距
       // 6px 2px 6px 10px、gap 8px、圆角 12px、16×16 图标；颜色/悬停用侧边栏同一
       // CSS 变量（--dsw-alias-label-primary / interactive-bg-hover），明暗主题下与
@@ -826,8 +851,16 @@ window.__ModuleLoader__.load({
         cursor: "pointer",
       };
       const triggerStyle = floating
-        ? { ...baseStyle, position: "fixed", left: "8px", bottom: "132px", zIndex: 10000, width: rail ? "auto" : "264px", height: rail ? "auto" : "34px" }
-        : { ...baseStyle, width: "100%", minHeight: rail ? undefined : "34px" };
+        ? {
+          ...baseStyle, position: "fixed",
+          left: Math.round(anchor.left) + "px",
+          bottom: Math.round(window.innerHeight - anchor.top + 6) + "px",
+          zIndex: 10000,
+          width: rail ? "auto" : Math.round(anchor.width) + "px",
+          height: rail ? "auto" : "34px",
+          whiteSpace: "nowrap",
+        }
+        : { ...baseStyle, width: "100%", minHeight: rail ? undefined : "34px", whiteSpace: "nowrap" };
       const hoverBg = "var(--dsw-alias-interactive-bg-hover)";
       return React.createElement(React.Fragment, null,
         !open && React.createElement("button", {

--- a/lib/client.js
+++ b/lib/client.js
@@ -782,8 +782,10 @@ window.__ModuleLoader__.load({
      * footerActions 是不换行的 256px flex 行；cordis 徽标 `flex:0 0 auto;
      * width:256px`、市场 launcher `flex:none; width:calc(100% + 4px)` 均不可
      * 收缩、占满整行，会把同槽其它条目挤出容器并被侧边栏 overflow:hidden 裁剪、
-     * 或挤成竖排窄条（实测）。fixed + 高 z-index 让任何 footer occupant 都挡不
-     * 住；样式对齐设置按钮（透明底、12px 圆角、16px 图标 + 文字、悬停浅底），
+     * 或挤成竖排窄条（实测）。fixed + z-index 1（与侧边栏内容同层，低于一切弹
+     * 层/遮罩——第三方插件弹层 30/40、shell 弹层 100、市场/设置模态 1000）让
+     * footer occupant 挡不住、任何弹出框体打开时都被自然盖住（压暗且点击被拦
+     * 截）；样式对齐设置按钮（透明底、12px 圆角、16px 图标 + 文字、悬停浅底），
      * 图标用插件 logo；rail（wide=false）态只显图标。
      */
     /** 检测 footer 行内的「整行占用者」：官方 cordis 徽标（[data-cordis-badge]，
@@ -855,7 +857,11 @@ window.__ModuleLoader__.load({
           ...baseStyle, position: "fixed",
           left: Math.round(anchor.left) + "px",
           bottom: Math.round(window.innerHeight - anchor.top + 6) + "px",
-          zIndex: 10000,
+          // 层级 1：与侧边栏普通内容同层，低于一切弹层/遮罩（第三方插件
+          // 弹层 30/40、shell 弹层 100、插件市场/设置模态 1000）。任何弹出
+          // 框体打开时都自然盖住本按钮——压暗且点击被遮罩拦截，与其余 UI
+          // 行为一致；不能用高 z-index 浮在弹层上。
+          zIndex: 1,
           width: rail ? "auto" : Math.round(anchor.width) + "px",
           height: rail ? "auto" : "34px",
           whiteSpace: "nowrap",

--- a/lib/client.js
+++ b/lib/client.js
@@ -776,17 +776,22 @@ window.__ModuleLoader__.load({
           fill: "currentColor" }));
     }
 
-    /** 触发按钮：footer 行内出现整行占用者（官方 cordis 徽标 / 内置插件市场
-     * launcher）时 fixed 浮动（脱离 footer.action 行布局），锚定到占用者正上方
-     * 独占一行、左缘与宽度对齐，形成并行两行；无占用者时落回行内全宽条目。
-     * footerActions 是不换行的 256px flex 行；cordis 徽标 `flex:0 0 auto;
+    /** 触发按钮：两种布局模式自适应。
+     * 1) 槽容器已被其它插件（如 dsh-tokenledger）注入 flex-wrap:wrap → 落回
+     *    行内独占一行，order 决定堆叠（tokenledger -10 / 本按钮 0 / 插件市场
+     *    10），无任何浮层；
+     * 2) 容器 nowrap 且行内出现整行占用者（官方 cordis 徽标 / 内置插件市场
+     *    launcher）→ fixed 浮动（脱离 footer.action 行布局），锚定到占用者
+     *    正上方独占一行、左缘与宽度对齐，形成并行两行；无占用者时落回行内。
+     * footerActions 默认是不换行的 256px flex 行；cordis 徽标 `flex:0 0 auto;
      * width:256px`、市场 launcher `flex:none; width:calc(100% + 4px)` 均不可
-     * 收缩、占满整行，会把同槽其它条目挤出容器并被侧边栏 overflow:hidden 裁剪、
-     * 或挤成竖排窄条（实测）。fixed + z-index 1（与侧边栏内容同层，低于一切弹
-     * 层/遮罩——第三方插件弹层 30/40、shell 弹层 100、市场/设置模态 1000）让
-     * footer occupant 挡不住、任何弹出框体打开时都被自然盖住（压暗且点击被拦
-     * 截）；样式对齐设置按钮（透明底、12px 圆角、16px 图标 + 文字、悬停浅底），
-     * 图标用插件 logo；rail（wide=false）态只显图标。
+     * 收缩、占满整行，nowrap 时会把同槽其它条目挤出容器并被侧边栏
+     * overflow:hidden 裁剪、或挤成竖排窄条（实测）。fixed + z-index 1（与侧
+     * 边栏内容同层，低于一切弹层/遮罩——第三方插件弹层 30/40、shell 弹层
+     * 100、市场/设置模态 1000）让 footer occupant 挡不住、任何弹出框体打开
+     * 时都被自然盖住（压暗且点击被拦截）；样式对齐设置按钮（透明底、12px
+     * 圆角、16px 图标 + 文字、悬停浅底），图标用插件 logo；rail（wide=false）
+     * 态只显图标。
      */
     /** 检测 footer 行内的「整行占用者」：官方 cordis 徽标（[data-cordis-badge]，
      * `flex:none; width:256px`）与内置插件市场 launcher（.dshMarketLauncher，
@@ -809,18 +814,32 @@ window.__ModuleLoader__.load({
       return best;
     };
 
+    /** 槽容器是否已被其它插件（如 dsh-tokenledger）注入 flex-wrap:wrap：
+     * wrap 时整行宽条目各自成行（order 决定上下顺序），本按钮落回行内即
+     * 可、无需浮层。经 data-slot 锚点的父元素判定，不依赖 CSS-module 哈希类。 */
+    const footerWraps = () => {
+      if (typeof document === "undefined") return false;
+      const marker = document.querySelector("[data-slot='sidebar.footer.action']");
+      if (!marker || !marker.parentElement) return false;
+      return getComputedStyle(marker.parentElement).flexWrap === "wrap";
+    };
+
     function ImportButton({ wide }) {
       const t = useTranslate();
       const [open, setOpen] = useState(false);
       const rail = wide === false;
-      // footer 行内有整行占用者（cordis 徽标 / 插件市场 launcher）→ fixed 浮层
-      // 独占一行，锚定到占用者正上方、左缘与宽度与之对齐（并行两行，互不挤压）；
-      // 无占用者 → 落回 footer 行内（普通全宽条目）。MutationObserver + resize
-      // 跟踪占用者的增删/显隐/位移；setAnchor 做等值比较防止观察自身 DOM 变化
-      // 造成重渲染循环。
+      // 槽容器已 wrap（tokenledger 等插件注入 flex-wrap）→ 落回行内独占一行，
+      // order 决定上下（tokenledger -10 / 本按钮 0 / 插件市场 10）；
+      // nowrap 且有整行占用者（cordis 徽标 / 插件市场 launcher）→ fixed 浮层
+      // 独占一行，锚定到占用者正上方、左缘与宽度与之对齐；
+      // nowrap 且无占用者 → 行内全宽条目。MutationObserver（观察根元素，含
+      // head 里样式表的增删）+ resize 跟踪占用者与 wrap 状态变化；状态更新做
+      // 等值比较防止观察自身 DOM 变化造成重渲染循环。
+      const [wraps, setWraps] = useState(() => footerWraps());
       const [anchor, setAnchor] = useState(() => footerOccupantRect());
       useEffect(() => {
         const check = () => {
+          setWraps(footerWraps());
           const next = footerOccupantRect();
           setAnchor((prev) => {
             if (!prev && !next) return prev;
@@ -831,14 +850,14 @@ window.__ModuleLoader__.load({
         };
         check();
         const mo = new MutationObserver(check);
-        mo.observe(document.body, {
+        mo.observe(document.documentElement, {
           childList: true, subtree: true, attributes: true,
           attributeFilter: ["data-cordis-badge", "style", "class"],
         });
         window.addEventListener("resize", check);
         return () => { mo.disconnect(); window.removeEventListener("resize", check); };
       }, []);
-      const floating = !!anchor;
+      const floating = !wraps && !!anchor;
       // 视觉逐项对齐侧边栏「设置」按钮（实测基准）：行高 22px、内边距
       // 6px 2px 6px 10px、gap 8px、圆角 12px、16×16 图标；颜色/悬停用侧边栏同一
       // CSS 变量（--dsw-alias-label-primary / interactive-bg-hover），明暗主题下与
@@ -866,7 +885,7 @@ window.__ModuleLoader__.load({
           height: rail ? "auto" : "34px",
           whiteSpace: "nowrap",
         }
-        : { ...baseStyle, width: "100%", minHeight: rail ? undefined : "34px", whiteSpace: "nowrap" };
+        : { ...baseStyle, flex: "0 0 100%", width: "100%", minHeight: rail ? undefined : "34px", whiteSpace: "nowrap" };
       const hoverBg = "var(--dsw-alias-interactive-bg-hover)";
       return React.createElement(React.Fragment, null,
         !open && React.createElement("button", {

--- a/lib/client.js
+++ b/lib/client.js
@@ -217,7 +217,9 @@ window.__ModuleLoader__.load({
     const makeStyles = (C) => ({
       overlay: { position: "fixed", inset: 0, background: "rgba(0,0,0,.45)", zIndex: 9998, display: "flex", justifyContent: "flex-end" },
       panel: {
-        position: "fixed", top: 0, right: 0, bottom: 0, width: "460px", maxWidth: "94vw",
+        // top 让出桌面端原生标题栏高度（Windows 窗口控制按钮 —□✕ 约 40px，
+        // 原生层恒在页面之上），否则面板头的 ✕ 与窗口 ✕ 重叠且点不到。
+        position: "fixed", top: "40px", right: 0, bottom: 0, width: "460px", maxWidth: "94vw",
         background: C.bg, borderLeft: "1px solid " + C.border, color: C.text,
         font: "13px/1.6 system-ui, sans-serif", zIndex: 9999, display: "flex", flexDirection: "column",
         boxShadow: "-8px 0 32px rgba(0,0,0,.35)",

--- a/lib/client.js
+++ b/lib/client.js
@@ -887,8 +887,11 @@ window.__ModuleLoader__.load({
         }
         : { ...baseStyle, flex: "0 0 100%", width: "100%", minHeight: rail ? undefined : "34px", whiteSpace: "nowrap" };
       const hoverBg = "var(--dsw-alias-interactive-bg-hover)";
+      // 按钮常显：面板打开时全屏遮罩（z 9998）盖在内容层按钮之上，无需卸载；
+      // 行内布局下卸载会让整行消失、footer 堆叠跳动（早期 z-index 10000 时代
+      // 按钮会浮在自己的面板上才卸载，层级降到 1 后该保护已多余）。
       return React.createElement(React.Fragment, null,
-        !open && React.createElement("button", {
+        React.createElement("button", {
           style: triggerStyle, title: t("trigger.title"),
           "aria-label": t("trigger.label"),
           onClick: () => setOpen(true),


### PR DESCRIPTION
﻿## 问题

DSH Desktop 中同时启用本插件与内置插件市场（dsh-community-market）时，侧边栏底部的「导入会话」按钮与「插件市场」按钮挤在同一行：「导入会话」被压缩成约一个字符宽的竖条，文字逐字竖排，几乎不可读也不可点。

## 根因

1. 侧边栏 `sidebar.footer.action` 槽的容器（`.footerActions`）是一条**不换行的 flex 行**；
2. 内置插件市场的 launcher（`.dshMarketLauncher`）样式为 `flex: none; width: calc(100% + 4px)`，与官方 cordis 徽标（`[data-cordis-badge]`）一样是不可收缩、占满整行的条目；
3. 本插件 `ImportButton` 只在检测到 cordis 徽标可见时才切换为 fixed 浮层，**未检测插件市场 launcher**。在无 cordis 徽标、但有插件市场的 profile 里，按钮回落行内布局，被整行宽的市场按钮挤压成竖条。

## 修复

把「仅 cordis 徽标在场时浮起」推广为「**任何整行 footer 占用者在场时浮起，锚定到其正上方**」，两按钮并行两行、互不挤压：

- `cordisBadgeVisible()` → `footerOccupantRect()`：同时识别 `[data-cordis-badge]` 与 `.dshMarketLauncher`，返回最靠上的可见占用者的视口矩形；
- 浮动定位由写死的 `left:8px; bottom:132px; width:264px` 改为按占用者矩形动态锚定：左缘/宽度与占用者精确对齐，`bottom = innerHeight - anchor.top + 6`，正好停在占用者上方独占一行；
- MutationObserver 之外增加 resize 监听；`setAnchor` 等值比较，避免观察自身 DOM 变化引发重渲染循环；
- 兜底：浮动与行内两种模式均加 `whiteSpace: nowrap`，未来再遇未知挤压也不会退化为竖排文字。

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 仅 cordis 徽标 | fixed @ bottom:132px（写死） | 锚定徽标正上方，左缘/宽度对齐 |
| 仅插件市场 | 行内被挤成竖条 ❌ | 锚定市场按钮正上方，并行两行 ✅ |
| 两者都在 | fixed @ 132px | 锚定最靠上的占用者，避开两者 |
| 都没有 | 行内全宽条目 | 不变 |

## 验证

- DSH Desktop（Windows）profile 装有 cordis 预设 + 内置插件市场；
- 修改前复现竖排窄条；修改后刷新页面，「导入会话」与「插件市场」上下两行并行、左缘对齐；
- 折叠侧边栏（rail 态）只显图标，锚定在市场圆形按钮上方，正常；
- 开/关滑出面板、Esc 关闭、面板内导入/同步流程均不受影响；
- `node --check lib/client.js` 通过。

改动全部在 `lib/client.js` 的 `ImportButton` 与其检测函数内（+56 / -23），不涉及面板、同步、设置页等其它逻辑。
