### PR TITLE
fix: 补全空 hint 命令的 input.hint，修复插件加载失败自动回滚

### DIFF
--- a/lib/command.mjs
+++ b/lib/command.mjs
@@ -269,7 +269,7 @@ export function registerImportCommand(ctx, registryDir) {
       description:
         '只读健康检查：imports registry、导入会话存在性、skills 落盘、workspaceRegistry 可用性。' +
         '对标 dsh-movein doctor；不写任何文件。',
-      input: { hint: '' },
+      input: { hint: '无需参数' },
       async handler() {
         try {
           const out = await runDoctor(ctx, registryDir)
@@ -288,7 +288,7 @@ export function registerImportCommand(ctx, registryDir) {
       description:
         '只读扫描 Claude .mcp.json / ~/.claude.json 与 Codex config.toml 中的 MCP server，' +
         '列出名称/来源/命令。不写任何文件；需要生成 DSH MCP client 片段请用 import_mcp 工具。',
-      input: { hint: '' },
+      input: { hint: '无需参数' },
       async handler() {
         try {
           const out = await runMcpMirror(ctx, {})
@@ -308,7 +308,7 @@ export function registerImportCommand(ctx, registryDir) {
       description:
         '只读解析 Claude settings.json 与 Codex config.toml，列出迁移到 DSH 时的建议与不可直接映射项。' +
         '不写任何文件；需要生成配置时请人工按建议处理。',
-      input: { hint: '' },
+      input: { hint: '无需参数' },
       async handler() {
         try {
           const out = await runSettingsSuggest(ctx, {})
@@ -328,7 +328,7 @@ export function registerImportCommand(ctx, registryDir) {
       description:
         '清空扫描缓存（进程内 30s TTL + $DSH_HOME/dsh-chat-import/scan-cache.json 持久书签）。' +
         '已导入会话和 imports registry 不受影响；适合扫描结果疑似过期时强制重扫。',
-      input: { hint: '' },
+      input: { hint: '无需参数' },
       async handler() {
         try {
           clearScanCache()

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -112,6 +112,21 @@ test('REQ-42 /import 命令注册契约（name/description/input.hint）', () =>
   assert.equal(typeof cmd.handler, 'function')
 })
 
+// REQ-42 所有命令 input.hint 非空：dsh-commands 的 normalizeDefinition 对空
+// hint（hint: ''）会硬抛 TypeError，导致插件 apply 阶段加载失败、被 DSH 启动
+// 校验自动回滚。凡带 input 的命令，hint 必须是含非空白字符的字符串。
+test('REQ-42 全部命令 input.hint 非空（空 hint 会致插件加载失败回滚）', () => {
+  const { getAllCommands } = setup()
+  const commands = getAllCommands()
+  assert.ok(commands.length >= 7, `应注册 7 条命令，实际 ${commands.length}`)
+  for (const c of commands) {
+    if (c.input) {
+      assert.equal(typeof c.input.hint, 'string', `命令 ${c.name} 的 input.hint 应为字符串`)
+      assert.ok(c.input.hint.trim().length > 0, `命令 ${c.name} 的 input.hint 不能为空（''）`)
+    }
+  }
+})
+
 test('REQ-42 /import claude <path>：单文件导入成功并落盘会话', async () => {
   const { cmd, sessions, attached } = setup()
   const file = join(mkdtempSync(join(tmpdir(), 'dsh-cmd-src-')), 'cmd-sess.jsonl')


### PR DESCRIPTION
/doctor、/mcp-status、/settings-suggest、/import-reset 的 input.hint 为空字符串，会被 dsh-commands 的 normalizeDefinition 硬抛 \input hint must not be empty\（TypeError）。

该错误发生在插件 apply 阶段，被 cordis-plugin-loader 判为 entry 加载失败 → DSH 启动校验失败 → 自动回滚，导致从 npm/GitHub main 装的版本无法生效。

将 4 处 hint 补全为 '无需参数'，并新增回归测试断言所有带 input 的命令 hint 非空。

## What & why

<!-- One or two sentences: the change and the reason (link issue / REQ id if any). -->

## Verification

- [ ] `npm test` green
- [ ] `npm run check:linux` green
- [ ] `npm run lint` green
- [ ] README.md / README.zh-CN.md synced (if behavior or docs changed)
- [ ] `git diff --cached --check` clean

## Notes

<!-- Anything reviewers should know: fixture approach, edge cases, follow-ups. -->
